### PR TITLE
Add UI controls for profile loaders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ set(PROJECT_SOURCES
         src/CameraMetadata.cpp
         src/CameraFrameMetadata.cpp
         src/AudioWriter.cpp
+        src/CalibrationProfile.cpp
+        src/CameraSettings.cpp
         src/Utils.cpp
 
         include/mainwindow.h
@@ -35,6 +37,8 @@ set(PROJECT_SOURCES
         include/SingleApplication.h
         include/CameraMetadata.h
         include/CameraFrameMetadata.h
+        include/CalibrationProfile.h
+        include/CameraSettings.h
         include/Utils.h
 
         ui/mainwindow.ui

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # MotionCam Virtual File System
 
 Work in progress
+
+## Calibration profiles and camera settings
+
+Two helper loaders are available for JSON configuration files:
+
+```cpp
+#include "CalibrationProfile.h"
+#include "CameraSettings.h"
+
+auto profiles = motioncam::loadCalibrationProfilesFromFile("camera-matrix.json");
+auto settings = motioncam::loadCameraSettingsFromFile("camera-name.json");
+```
+
+These functions parse the provided JSON files into in-memory maps. The example
+`camera-matrix.json` and `camera-name.json` files in the repository illustrate
+the expected structure.
+
+The main window now lets you choose these JSON files using two "Browse" buttons
+for camera settings and calibration profiles.

--- a/camera-matrix.json
+++ b/camera-matrix.json
@@ -1,0 +1,22 @@
+{
+  "Matrix Set 1": {
+    "colorMatrix1": [1, 0, 0, 0, 1, 0, 0, 0, 1],
+    "colorMatrix2": [1, 0, 0, 0, 1, 0, 0, 0, 1],
+    "forwardMatrix1": [1, 0, 0, 0, 1, 0, 0, 0, 1],
+    "forwardMatrix2": [1, 0, 0, 0, 1, 0, 0, 0, 1],
+    "calibrationMatrix1": [0.5234375, 0, 0, 0, 1, 0, 0, 0, 0.5625],
+    "calibrationMatrix2": [1, 0, 0, 0, 1, 0, 0, 0, 1],
+    "colorIlluminant2": "standarda",
+    "colorIlluminant1": "d65"
+  },
+  "Matrix Set 2": {
+    "uniqueCameraModel": "Panasonic Generic",
+    "colorMatrix1": [1, 0, 0, 0, 1, 0, 0, 0, 1],
+    "colorMatrix2": [1, 0, 0, 0, 1, 0, 0, 0, 1],
+    "forwardMatrix1": [1, 0, 0, 0, 1, 0, 0, 0, 1],
+    "forwardMatrix2": [1, 0, 0, 0, 1, 0, 0, 0, 1],
+    "calibrationMatrix1": [0.5234375, 0, 0, 0, 1, 0, 0, 0, 0.5625],
+    "calibrationMatrix2": [1, 0, 0, 0, 1, 0, 0, 0, 1]
+  }
+}
+

--- a/camera-name.json
+++ b/camera-name.json
@@ -1,0 +1,4 @@
+{
+  "Blackmagic URSA Mini 4.6K": { "uniqueCameraModel": "Blackmagic URSA Mini 4.6K" },
+  "Panasonic Generic": { "uniqueCameraModel": "Panasonic Generic" }
+}

--- a/include/CalibrationProfile.h
+++ b/include/CalibrationProfile.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <array>
+#include <string>
+#include <unordered_map>
+
+namespace motioncam {
+
+struct CalibrationProfile {
+    std::optional<std::array<float, 9>> colorMatrix1;
+    std::optional<std::array<float, 9>> colorMatrix2;
+    std::optional<std::array<float, 9>> forwardMatrix1;
+    std::optional<std::array<float, 9>> forwardMatrix2;
+    std::optional<std::array<float, 9>> calibrationMatrix1;
+    std::optional<std::array<float, 9>> calibrationMatrix2;
+    std::optional<std::string> colorIlluminant1;
+    std::optional<std::string> colorIlluminant2;
+    std::optional<std::string> uniqueCameraModel;
+
+    static CalibrationProfile fromJson(const nlohmann::json& j);
+};
+
+using CalibrationProfileMap = std::unordered_map<std::string, CalibrationProfile>;
+
+CalibrationProfileMap loadCalibrationProfiles(const std::string& jsonString);
+CalibrationProfileMap loadCalibrationProfilesFromFile(const std::string& filename);
+
+} // namespace motioncam
+

--- a/include/CameraSettings.h
+++ b/include/CameraSettings.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <unordered_map>
+#include <optional>
+#include <string>
+
+namespace motioncam {
+
+struct CameraSettings {
+    std::optional<std::string> uniqueCameraModel;
+
+    static CameraSettings fromJson(const nlohmann::json& j);
+};
+
+using CameraSettingsMap = std::unordered_map<std::string, CameraSettings>;
+
+CameraSettingsMap loadCameraSettings(const std::string& jsonString);
+CameraSettingsMap loadCameraSettingsFromFile(const std::string& filename);
+
+} // namespace motioncam
+

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -2,6 +2,8 @@
 #define MAINWINDOW_H
 
 #include "IFuseFileSystem.h"
+#include "CameraSettings.h"
+#include "CalibrationProfile.h"
 
 #include <QMainWindow>
 #include <QList>
@@ -66,6 +68,8 @@ private slots:
     void onRenderSettingsChanged(const Qt::CheckState &state);
     void onDraftModeQualityChanged(int index);
     void onSetCacheFolder(bool checked);
+    void onSetCameraSettingsFile(bool checked);
+    void onSetCalibrationProfileFile(bool checked);
 
     void playFile(const QString& path);
     void removeFile(QWidget* fileWidget);
@@ -80,6 +84,10 @@ private:
     std::unique_ptr<motioncam::IFuseFileSystem> mFuseFilesystem;
     QList<motioncam::MountedFile> mMountedFiles;
     QString mCacheRootFolder;
+    QString mCameraSettingsFile;
+    QString mCalibrationProfileFile;
+    motioncam::CameraSettingsMap mCameraSettings;
+    motioncam::CalibrationProfileMap mCalibrationProfiles;
     int mDraftQuality;
 };
 

--- a/src/CalibrationProfile.cpp
+++ b/src/CalibrationProfile.cpp
@@ -1,0 +1,67 @@
+#include "CalibrationProfile.h"
+#include <fstream>
+#include <sstream>
+
+using json = nlohmann::json;
+
+namespace motioncam {
+
+namespace {
+    template<typename T, std::size_t N>
+    std::array<T, N> parseArray(const json& arr) {
+        std::array<T, N> result{};
+        for(std::size_t i = 0; i < N && i < arr.size(); ++i)
+            result[i] = arr[i].get<T>();
+        return result;
+    }
+}
+
+CalibrationProfile CalibrationProfile::fromJson(const json& j) {
+    CalibrationProfile profile;
+
+    if(j.contains("colorMatrix1"))
+        profile.colorMatrix1 = parseArray<float,9>(j["colorMatrix1"]);
+    if(j.contains("colorMatrix2"))
+        profile.colorMatrix2 = parseArray<float,9>(j["colorMatrix2"]);
+    if(j.contains("forwardMatrix1"))
+        profile.forwardMatrix1 = parseArray<float,9>(j["forwardMatrix1"]);
+    if(j.contains("forwardMatrix2"))
+        profile.forwardMatrix2 = parseArray<float,9>(j["forwardMatrix2"]);
+    if(j.contains("calibrationMatrix1"))
+        profile.calibrationMatrix1 = parseArray<float,9>(j["calibrationMatrix1"]);
+    if(j.contains("calibrationMatrix2"))
+        profile.calibrationMatrix2 = parseArray<float,9>(j["calibrationMatrix2"]);
+
+    if(j.contains("colorIlluminant1"))
+        profile.colorIlluminant1 = j["colorIlluminant1"].get<std::string>();
+    if(j.contains("colorIlluminant2"))
+        profile.colorIlluminant2 = j["colorIlluminant2"].get<std::string>();
+    if(j.contains("uniqueCameraModel"))
+        profile.uniqueCameraModel = j["uniqueCameraModel"].get<std::string>();
+
+    return profile;
+}
+
+CalibrationProfileMap loadCalibrationProfiles(const std::string& jsonString) {
+    json j = json::parse(jsonString);
+    CalibrationProfileMap profiles;
+
+    for(const auto& item : j.items()) {
+        profiles[item.key()] = CalibrationProfile::fromJson(item.value());
+    }
+
+    return profiles;
+}
+
+CalibrationProfileMap loadCalibrationProfilesFromFile(const std::string& filename) {
+    std::ifstream f(filename);
+    if(!f.is_open()) {
+        throw std::runtime_error("Failed to open calibration profile file: " + filename);
+    }
+    std::stringstream buffer;
+    buffer << f.rdbuf();
+    return loadCalibrationProfiles(buffer.str());
+}
+
+} // namespace motioncam
+

--- a/src/CameraSettings.cpp
+++ b/src/CameraSettings.cpp
@@ -1,0 +1,38 @@
+#include "CameraSettings.h"
+#include <fstream>
+#include <sstream>
+
+using json = nlohmann::json;
+
+namespace motioncam {
+
+CameraSettings CameraSettings::fromJson(const json& j) {
+    CameraSettings settings;
+    if(j.contains("uniqueCameraModel"))
+        settings.uniqueCameraModel = j["uniqueCameraModel"].get<std::string>();
+    return settings;
+}
+
+CameraSettingsMap loadCameraSettings(const std::string& jsonString) {
+    json j = json::parse(jsonString);
+    CameraSettingsMap settings;
+
+    for(const auto& item : j.items()) {
+        settings[item.key()] = CameraSettings::fromJson(item.value());
+    }
+
+    return settings;
+}
+
+CameraSettingsMap loadCameraSettingsFromFile(const std::string& filename) {
+    std::ifstream f(filename);
+    if(!f.is_open()) {
+        throw std::runtime_error("Failed to open camera settings file: " + filename);
+    }
+    std::stringstream buffer;
+    buffer << f.rdbuf();
+    return loadCameraSettings(buffer.str());
+}
+
+} // namespace motioncam
+

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -11,6 +11,8 @@
 #include <QFileDialog>
 #include <QSettings>
 #include <algorithm>
+#include "CameraSettings.h"
+#include "CalibrationProfile.h"
 
 #ifdef _WIN32
 #include "win/FuseFileSystemImpl_Win.h"
@@ -60,6 +62,8 @@ MainWindow::MainWindow(QWidget *parent)
     connect(ui->draftQuality, &QComboBox::currentIndexChanged, this, &MainWindow::onDraftModeQualityChanged);
 
     connect(ui->changeCacheBtn, &QPushButton::clicked, this, &MainWindow::onSetCacheFolder);
+    connect(ui->changeCameraSettingsBtn, &QPushButton::clicked, this, &MainWindow::onSetCameraSettingsFile);
+    connect(ui->changeCalibrationProfileBtn, &QPushButton::clicked, this, &MainWindow::onSetCalibrationProfileFile);
 }
 
 MainWindow::~MainWindow() {
@@ -75,6 +79,8 @@ void MainWindow::saveSettings() {
     settings.setValue("applyVignetteCorrection", ui->vignetteCorrectionCheckBox->checkState() == Qt::CheckState::Checked);
     settings.setValue("scaleRaw", ui->scaleRawCheckBox->checkState() == Qt::CheckState::Checked);
     settings.setValue("cachePath", mCacheRootFolder);
+    settings.setValue("cameraSettingsFile", mCameraSettingsFile);
+    settings.setValue("calibrationProfileFile", mCalibrationProfileFile);
     settings.setValue("draftQuality", mDraftQuality);
 
     // Save mounted files
@@ -100,8 +106,28 @@ void MainWindow::restoreSettings() {
     ui->scaleRawCheckBox->setCheckState(
         settings.value("scaleRaw").toBool() ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);
 
-    mCacheRootFolder = settings.value("cachePath").toString();    
+    mCacheRootFolder = settings.value("cachePath").toString();
+    mCameraSettingsFile = settings.value("cameraSettingsFile").toString();
+    mCalibrationProfileFile = settings.value("calibrationProfileFile").toString();
     mDraftQuality = std::max(1, settings.value("draftQuality").toInt());
+
+    if(!mCameraSettingsFile.isEmpty()) {
+        try {
+            mCameraSettings = motioncam::loadCameraSettingsFromFile(mCameraSettingsFile.toStdString());
+        } catch(const std::exception& e) {
+            QMessageBox::warning(this, "Warning", QString("Failed to load camera settings: %1").arg(e.what()));
+            mCameraSettings.clear();
+        }
+    }
+
+    if(!mCalibrationProfileFile.isEmpty()) {
+        try {
+            mCalibrationProfiles = motioncam::loadCalibrationProfilesFromFile(mCalibrationProfileFile.toStdString());
+        } catch(const std::exception& e) {
+            QMessageBox::warning(this, "Warning", QString("Failed to load calibration profiles: %1").arg(e.what()));
+            mCalibrationProfiles.clear();
+        }
+    }
 
     if(mDraftQuality == 2)
         ui->draftQuality->setCurrentIndex(0);
@@ -293,6 +319,8 @@ void MainWindow::updateUi() {
         ui->scaleRawCheckBox->setEnabled(false);
 
     ui->cacheFolderLabel->setText(mCacheRootFolder);
+    ui->cameraSettingsLabel->setText(mCameraSettingsFile.isEmpty() ? "-" : mCameraSettingsFile);
+    ui->calibrationProfileLabel->setText(mCalibrationProfileFile.isEmpty() ? "-" : mCalibrationProfileFile);
 }
 
 void MainWindow::onRenderSettingsChanged(const Qt::CheckState &checkState) {
@@ -331,3 +359,34 @@ void MainWindow::onSetCacheFolder(bool checked) {
     mCacheRootFolder = folderPath;
     ui->cacheFolderLabel->setText(mCacheRootFolder);
 }
+
+void MainWindow::onSetCameraSettingsFile(bool checked) {
+    Q_UNUSED(checked);
+    QString filePath = QFileDialog::getOpenFileName(this, tr("Select Camera Settings"), QString(), tr("JSON Files (*.json)"));
+    if(!filePath.isEmpty()) {
+        mCameraSettingsFile = filePath;
+        try {
+            mCameraSettings = motioncam::loadCameraSettingsFromFile(filePath.toStdString());
+        } catch(const std::exception& e) {
+            QMessageBox::warning(this, "Warning", QString("Failed to load camera settings: %1").arg(e.what()));
+            mCameraSettings.clear();
+        }
+        ui->cameraSettingsLabel->setText(mCameraSettingsFile);
+    }
+}
+
+void MainWindow::onSetCalibrationProfileFile(bool checked) {
+    Q_UNUSED(checked);
+    QString filePath = QFileDialog::getOpenFileName(this, tr("Select Calibration Profiles"), QString(), tr("JSON Files (*.json)"));
+    if(!filePath.isEmpty()) {
+        mCalibrationProfileFile = filePath;
+        try {
+            mCalibrationProfiles = motioncam::loadCalibrationProfilesFromFile(filePath.toStdString());
+        } catch(const std::exception& e) {
+            QMessageBox::warning(this, "Warning", QString("Failed to load calibration profiles: %1").arg(e.what()));
+            mCalibrationProfiles.clear();
+        }
+        ui->calibrationProfileLabel->setText(mCalibrationProfileFile);
+    }
+}
+

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -91,7 +91,7 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
+      <item row="1" column="0">
         <layout class="QHBoxLayout" name="cacheLayout">
          <item>
           <widget class="QLabel" name="descCacheFolder">
@@ -133,8 +133,94 @@
           </widget>
          </item>
         </layout>
-       </item>
-       <item row="0" column="1">
+      </item>
+      <item row="2" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="cameraSettingsLayout">
+        <item>
+         <widget class="QLabel" name="descCameraSettings">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Camera Settings:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="cameraSettingsLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>-</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="changeCameraSettingsBtn">
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>30</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Browse</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="calibrationProfileLayout">
+        <item>
+         <widget class="QLabel" name="descCalibrationProfile">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Calibration Profiles:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="calibrationProfileLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>-</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="changeCalibrationProfileBtn">
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>30</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Browse</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="1">
         <widget class="QCheckBox" name="vignetteCorrectionCheckBox">
          <property name="enabled">
           <bool>true</bool>


### PR DESCRIPTION
## Summary
- add camera settings and calibration profile selection to the main window
- save/restore selected JSON files via QSettings
- display chosen filenames in the UI
- document new UI controls in README

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_684acf72970c83278e5407fcead7f47a