### PR TITLE
Implement menu and settings dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(PROJECT_SOURCES
         src/CameraFrameMetadata.cpp
         src/AudioWriter.cpp
         src/Utils.cpp
+        src/SettingsDialog.cpp
 
         include/mainwindow.h
         include/Types.h
@@ -36,8 +37,10 @@ set(PROJECT_SOURCES
         include/CameraMetadata.h
         include/CameraFrameMetadata.h
         include/Utils.h
+        include/SettingsDialog.h
 
         ui/mainwindow.ui
+        ui/SettingsDialog.ui
 )
 
 qt_add_resources(PROJECT_SOURCES resources.qrc)

--- a/help/index.html
+++ b/help/index.html
@@ -1,0 +1,1 @@
+<html><body><h1>MotionCam FS Demo</h1><p>Demo help page.</p></body></html>

--- a/include/SettingsDialog.h
+++ b/include/SettingsDialog.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <QDialog>
+#include <QMap>
+
+namespace Ui {
+class SettingsDialog;
+}
+
+class SettingsDialog : public QDialog {
+    Q_OBJECT
+public:
+    explicit SettingsDialog(QWidget* parent = nullptr);
+    ~SettingsDialog();
+
+    QString cachePath() const;
+    void setCachePath(const QString& path);
+    QMap<QString, QString> uniqueNames() const;
+    void setUniqueNames(const QMap<QString, QString>& names);
+
+private slots:
+    void onBrowseCache();
+
+private:
+    Ui::SettingsDialog* ui;
+};

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -65,7 +65,9 @@ protected:
 private slots:
     void onRenderSettingsChanged(const Qt::CheckState &state);
     void onDraftModeQualityChanged(int index);
-    void onSetCacheFolder(bool checked);
+    void onShowOptions();
+    void onUnmountAll();
+    void onShowHelp();
 
     void playFile(const QString& path);
     void removeFile(QWidget* fileWidget);

--- a/resources.qrc
+++ b/resources.qrc
@@ -4,5 +4,6 @@
         <file>assets/app_icon.png</file>
         <file>assets/play_btn.png</file>
         <file>assets/remove_btn.png</file>
+        <file>help/index.html</file>
     </qresource>
 </RCC>

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -1,0 +1,49 @@
+#include "SettingsDialog.h"
+#include "ui_SettingsDialog.h"
+
+#include <QFileDialog>
+
+SettingsDialog::SettingsDialog(QWidget* parent) :
+    QDialog(parent), ui(new Ui::SettingsDialog) {
+    ui->setupUi(this);
+    connect(ui->browseCacheBtn, &QPushButton::clicked, this, &SettingsDialog::onBrowseCache);
+}
+
+SettingsDialog::~SettingsDialog() {
+    delete ui;
+}
+
+QString SettingsDialog::cachePath() const {
+    return ui->cacheEdit->text();
+}
+
+void SettingsDialog::setCachePath(const QString& path) {
+    ui->cacheEdit->setText(path);
+}
+
+QMap<QString, QString> SettingsDialog::uniqueNames() const {
+    QMap<QString, QString> result;
+    for(int r=0; r<ui->uniqueTable->rowCount(); ++r) {
+        result.insert(ui->uniqueTable->item(r,0)->text(), ui->uniqueTable->item(r,1)->text());
+    }
+    return result;
+}
+
+void SettingsDialog::setUniqueNames(const QMap<QString, QString>& names) {
+    ui->uniqueTable->setColumnCount(2);
+    ui->uniqueTable->setRowCount(names.size());
+    int row=0;
+    for(auto it = names.begin(); it != names.end(); ++it, ++row) {
+        ui->uniqueTable->setItem(row,0,new QTableWidgetItem(it.key()));
+        ui->uniqueTable->setItem(row,1,new QTableWidgetItem(it.value()));
+    }
+    QStringList headers;
+    headers<<"Camera Key"<<"Unique Camera Model";
+    ui->uniqueTable->setHorizontalHeaderLabels(headers);
+}
+
+void SettingsDialog::onBrowseCache() {
+    auto folder = QFileDialog::getExistingDirectory(this, tr("Select Cache Folder"));
+    if(!folder.isEmpty())
+        ui->cacheEdit->setText(folder);
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,5 +1,6 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
+#include "SettingsDialog.h"
 
 #include <QDragEnterEvent>
 #include <QDropEvent>
@@ -8,7 +9,9 @@
 #include <QFileInfo>
 #include <QProcess>
 #include <QMessageBox>
-#include <QFileDialog>
+#include <QDesktopServices>
+#include <QUrl>
+#include <QCoreApplication>
 #include <QSettings>
 #include <algorithm>
 
@@ -63,7 +66,11 @@ MainWindow::MainWindow(QWidget *parent)
     connect(ui->scaleRawCheckBox, &QCheckBox::checkStateChanged, this, &MainWindow::onRenderSettingsChanged);
     connect(ui->draftQuality, &QComboBox::currentIndexChanged, this, &MainWindow::onDraftModeQualityChanged);
 
-    connect(ui->changeCacheBtn, &QPushButton::clicked, this, &MainWindow::onSetCacheFolder);
+    connect(ui->actionOptions, &QAction::triggered, this, &MainWindow::onShowOptions);
+    connect(ui->actionUnmountAll, &QAction::triggered, this, &MainWindow::onUnmountAll);
+    connect(ui->actionExit, &QAction::triggered, this, &MainWindow::close);
+    connect(ui->actionDemo, &QAction::triggered, this, &MainWindow::onShowHelp);
+
 }
 
 MainWindow::~MainWindow() {
@@ -301,7 +308,6 @@ void MainWindow::updateUi() {
     else
         ui->scaleRawCheckBox->setEnabled(false);
 
-    ui->cacheFolderLabel->setText(mCacheRootFolder);
 }
 
 void MainWindow::onRenderSettingsChanged(const Qt::CheckState &checkState) {
@@ -327,16 +333,31 @@ void MainWindow::onDraftModeQualityChanged(int index) {
     onRenderSettingsChanged(Qt::CheckState::Checked);
 }
 
-void MainWindow::onSetCacheFolder(bool checked) {
-    Q_UNUSED(checked);  // Parameter not needed for folder selection
-
-    auto folderPath = QFileDialog::getExistingDirectory(
-        this,
-        tr("Select Cache Root Folder"),
-        QString(),  // Start from default location
-        QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks
-    );
-
-    mCacheRootFolder = folderPath;
-    ui->cacheFolderLabel->setText(mCacheRootFolder);
+void MainWindow::onShowOptions() {
+    SettingsDialog dlg(this);
+    dlg.setCachePath(mCacheRootFolder);
+    if(dlg.exec() == QDialog::Accepted) {
+        mCacheRootFolder = dlg.cachePath();
+        saveSettings();
+    }
 }
+
+void MainWindow::onUnmountAll() {
+    while(!mMountedFiles.isEmpty()) {
+        auto w = mMountedFiles.takeFirst();
+        mFuseFilesystem->unmount(w.mountId);
+    }
+    auto* scrollContent = ui->dragAndDropScrollArea->widget();
+    auto* layout = qobject_cast<QVBoxLayout*>(scrollContent->layout());
+    QLayoutItem* child;
+    while((child = layout->takeAt(0)) != nullptr) {
+        if(auto widget = child->widget()) widget->deleteLater();
+        delete child;
+    }
+    ui->dragAndDropLabel->show();
+}
+
+void MainWindow::onShowHelp() {
+    QDesktopServices::openUrl(QUrl::fromLocalFile(QCoreApplication::applicationDirPath()+"/help/index.html"));
+}
+

--- a/ui/SettingsDialog.ui
+++ b/ui/SettingsDialog.ui
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SettingsDialog</class>
+ <widget class="QDialog" name="SettingsDialog">
+  <property name="windowTitle">
+   <string>Options</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="cacheLayout">
+     <item><label class="QLabel" name="labelCache"><property name="text"><string>Cache Folder:</string></property></label></item>
+     <item><widget class="QLineEdit" name="cacheEdit"/></item>
+     <item><widget class="QPushButton" name="browseCacheBtn"><property name="text"><string>Change...</string></property></widget></item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="uniqueTable"/>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item><spacer name="spacer"><property name="orientation"><enum>Qt::Horizontal</enum></property><property name="sizeHint"><size><width>40</width><height>20</height></size></property></spacer></item>
+     <item><widget class="QPushButton" name="saveBtn"><property name="text"><string>Save</string></property></widget></item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -11,8 +11,54 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MotionCam FS</string>
-  </property>
+  <string>MotionCam FS</string>
+ </property>
+  <widget class="QMenuBar" name="menubar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>800</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <widget class="QMenu" name="menuFile">
+    <property name="title">
+     <string>File</string>
+    </property>
+    <addaction name="actionUnmountAll"/>
+    <addaction name="actionExit"/>
+   </widget>
+   <widget class="QMenu" name="menuHelp">
+    <property name="title">
+     <string>Help</string>
+    </property>
+    <addaction name="actionDemo"/>
+   </widget>
+   <addaction name="menuFile"/>
+   <addaction name="actionOptions"/>
+   <addaction name="menuHelp"/>
+  </widget>
+  <action name="actionUnmountAll">
+   <property name="text">
+    <string>Unmount All</string>
+   </property>
+  </action>
+  <action name="actionExit">
+   <property name="text">
+    <string>Exit</string>
+   </property>
+  </action>
+  <action name="actionOptions">
+   <property name="text">
+    <string>Options...</string>
+   </property>
+  </action>
+  <action name="actionDemo">
+   <property name="text">
+    <string>Demo</string>
+   </property>
+  </action>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
@@ -90,49 +136,6 @@
           <string>Scale RAW data</string>
          </property>
         </widget>
-       </item>
-       <item row="1" column="0">
-        <layout class="QHBoxLayout" name="cacheLayout">
-         <item>
-          <widget class="QLabel" name="descCacheFolder">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Cache Folder:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="cacheFolderLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>1</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>-</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="changeCacheBtn">
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>30</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Change</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </item>
        <item row="0" column="1">
         <widget class="QCheckBox" name="vignetteCorrectionCheckBox">


### PR DESCRIPTION
## Summary
- add a menu bar with File, Options, and Help
- implement SettingsDialog for cache folder settings
- wire actions for Options, Unmount All, and Help
- bundle demo HTML help page

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt)*

------
https://chatgpt.com/codex/tasks/task_e_684af5c85704832785658717f8b97a83