### PR TITLE
Implement improved Options dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(PROJECT_SOURCES
         src/CameraFrameMetadata.cpp
         src/AudioWriter.cpp
         src/Utils.cpp
+        src/SettingsDialog.cpp
 
         include/mainwindow.h
         include/Types.h
@@ -36,8 +37,10 @@ set(PROJECT_SOURCES
         include/CameraMetadata.h
         include/CameraFrameMetadata.h
         include/Utils.h
+        include/SettingsDialog.h
 
         ui/mainwindow.ui
+        ui/SettingsDialog.ui
 )
 
 qt_add_resources(PROJECT_SOURCES resources.qrc)

--- a/assets/matrix-camera.json
+++ b/assets/matrix-camera.json
@@ -1,0 +1,12 @@
+{
+    "Default": {
+        "colorMatrix1": [1,0,0,0,1,0,0,0,1],
+        "colorMatrix2": [1,0,0,0,1,0,0,0,1],
+        "forwardMatrix1": [1,0,0,0,1,0,0,0,1],
+        "forwardMatrix2": [1,0,0,0,1,0,0,0,1],
+        "calibrationMatrix1": [1,0,0,0,1,0,0,0,1],
+        "calibrationMatrix2": [1,0,0,0,1,0,0,0,1],
+        "colorIlluminant1": "D65",
+        "colorIlluminant2": "D50"
+    }
+}

--- a/assets/unique-name.json
+++ b/assets/unique-name.json
@@ -1,0 +1,4 @@
+{
+    "CameraKey1": "Camera Model A",
+    "CameraKey2": "Camera Model B"
+}

--- a/help/index.html
+++ b/help/index.html
@@ -1,0 +1,1 @@
+<html><body><h1>MotionCam FS Demo</h1><p>Demo help page.</p></body></html>

--- a/include/SettingsDialog.h
+++ b/include/SettingsDialog.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <QDialog>
+#include <QMap>
+
+namespace Ui {
+class SettingsDialog;
+}
+
+struct MatrixProfile {
+    QString colorMatrix1;
+    QString colorMatrix2;
+    QString forwardMatrix1;
+    QString forwardMatrix2;
+    QString calibrationMatrix1;
+    QString calibrationMatrix2;
+    QString illuminant1;
+    QString illuminant2;
+};
+
+class SettingsDialog : public QDialog {
+    Q_OBJECT
+public:
+    explicit SettingsDialog(QWidget* parent = nullptr);
+    ~SettingsDialog();
+
+    QString cachePath() const;
+    void setCachePath(const QString& path);
+    QMap<QString, QString> uniqueNames() const;
+    void setUniqueNames(const QMap<QString, QString>& names);
+    QMap<QString, MatrixProfile> matrixProfiles() const;
+    void setMatrixProfiles(const QMap<QString, MatrixProfile>& profiles);
+    QString currentMatrixKey() const;
+    void setCurrentMatrixKey(const QString& key);
+
+private slots:
+    void onBrowseCache();
+    void onMatrixSetChanged(int index);
+
+private:
+    Ui::SettingsDialog* ui;
+    QMap<QString, MatrixProfile> mMatrixProfiles;
+};

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -6,6 +6,7 @@
 #include <QMainWindow>
 #include <QList>
 #include <QString>
+#include "SettingsDialog.h"
 
 namespace motioncam {
     struct MountedFile {
@@ -65,7 +66,9 @@ protected:
 private slots:
     void onRenderSettingsChanged(const Qt::CheckState &state);
     void onDraftModeQualityChanged(int index);
-    void onSetCacheFolder(bool checked);
+    void onShowOptions();
+    void onUnmountAll();
+    void onShowHelp();
 
     void playFile(const QString& path);
     void removeFile(QWidget* fileWidget);
@@ -74,12 +77,19 @@ private:
     void saveSettings();
     void restoreSettings();
     void updateUi();
+    void loadUniqueNamesFromFile();
+    void loadMatrixProfilesFromFile();
+    void saveUniqueNamesToFile();
+    void saveMatrixProfilesToFile();
 
 private:
     Ui::MainWindow *ui;
     std::unique_ptr<motioncam::IFuseFileSystem> mFuseFilesystem;
     QList<motioncam::MountedFile> mMountedFiles;
     QString mCacheRootFolder;
+    QMap<QString, QString> mUniqueNames;
+    QMap<QString, MatrixProfile> mMatrixProfiles;
+    QString mCurrentMatrixKey;
     int mDraftQuality;
 };
 

--- a/resources.qrc
+++ b/resources.qrc
@@ -4,5 +4,6 @@
         <file>assets/app_icon.png</file>
         <file>assets/play_btn.png</file>
         <file>assets/remove_btn.png</file>
+        <file>help/index.html</file>
     </qresource>
 </RCC>

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -1,0 +1,104 @@
+#include "SettingsDialog.h"
+#include "ui_SettingsDialog.h"
+
+#include <QFileDialog>
+
+SettingsDialog::SettingsDialog(QWidget* parent) :
+    QDialog(parent), ui(new Ui::SettingsDialog) {
+    ui->setupUi(this);
+    connect(ui->browseCacheBtn, &QPushButton::clicked, this, &SettingsDialog::onBrowseCache);
+    connect(ui->saveBtn, &QPushButton::clicked, this, &SettingsDialog::accept);
+    connect(ui->cancelBtn, &QPushButton::clicked, this, &SettingsDialog::reject);
+    connect(ui->matrixCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsDialog::onMatrixSetChanged);
+}
+
+SettingsDialog::~SettingsDialog() {
+    delete ui;
+}
+
+QString SettingsDialog::cachePath() const {
+    return ui->cacheEdit->text();
+}
+
+void SettingsDialog::setCachePath(const QString& path) {
+    ui->cacheEdit->setText(path);
+}
+
+QMap<QString, QString> SettingsDialog::uniqueNames() const {
+    QMap<QString, QString> result;
+    for(int r=0; r<ui->uniqueTable->rowCount(); ++r) {
+        result.insert(ui->uniqueTable->item(r,0)->text(), ui->uniqueTable->item(r,1)->text());
+    }
+    return result;
+}
+
+void SettingsDialog::setUniqueNames(const QMap<QString, QString>& names) {
+    ui->uniqueTable->setColumnCount(2);
+    ui->uniqueTable->setRowCount(names.size());
+    int row=0;
+    for(auto it = names.begin(); it != names.end(); ++it, ++row) {
+        ui->uniqueTable->setItem(row,0,new QTableWidgetItem(it.key()));
+        ui->uniqueTable->setItem(row,1,new QTableWidgetItem(it.value()));
+    }
+    QStringList headers;
+    headers<<"Camera Key"<<"Unique Camera Model";
+    ui->uniqueTable->setHorizontalHeaderLabels(headers);
+}
+
+QMap<QString, MatrixProfile> SettingsDialog::matrixProfiles() const {
+    auto profiles = mMatrixProfiles;
+    auto key = ui->matrixCombo->currentText();
+    if(profiles.contains(key)) {
+        auto& p = profiles[key];
+        p.colorMatrix1 = ui->colorMatrix1Edit->text();
+        p.colorMatrix2 = ui->colorMatrix2Edit->text();
+        p.forwardMatrix1 = ui->forwardMatrix1Edit->text();
+        p.forwardMatrix2 = ui->forwardMatrix2Edit->text();
+        p.calibrationMatrix1 = ui->calibrationMatrix1Edit->text();
+        p.calibrationMatrix2 = ui->calibrationMatrix2Edit->text();
+        p.illuminant1 = ui->illuminant1Edit->text();
+        p.illuminant2 = ui->illuminant2Edit->text();
+    }
+    return profiles;
+}
+
+void SettingsDialog::setMatrixProfiles(const QMap<QString, MatrixProfile>& profiles) {
+    mMatrixProfiles = profiles;
+    ui->matrixCombo->clear();
+    for(auto it = profiles.begin(); it != profiles.end(); ++it)
+        ui->matrixCombo->addItem(it.key());
+    if(!profiles.isEmpty())
+        onMatrixSetChanged(0);
+}
+
+QString SettingsDialog::currentMatrixKey() const {
+    return ui->matrixCombo->currentText();
+}
+
+void SettingsDialog::setCurrentMatrixKey(const QString& key) {
+    int index = ui->matrixCombo->findText(key);
+    if(index >= 0)
+        ui->matrixCombo->setCurrentIndex(index);
+}
+
+void SettingsDialog::onMatrixSetChanged(int index) {
+    Q_UNUSED(index);
+    auto key = ui->matrixCombo->currentText();
+    if(!mMatrixProfiles.contains(key))
+        return;
+    const auto& p = mMatrixProfiles[key];
+    ui->colorMatrix1Edit->setText(p.colorMatrix1);
+    ui->colorMatrix2Edit->setText(p.colorMatrix2);
+    ui->forwardMatrix1Edit->setText(p.forwardMatrix1);
+    ui->forwardMatrix2Edit->setText(p.forwardMatrix2);
+    ui->calibrationMatrix1Edit->setText(p.calibrationMatrix1);
+    ui->calibrationMatrix2Edit->setText(p.calibrationMatrix2);
+    ui->illuminant1Edit->setText(p.illuminant1);
+    ui->illuminant2Edit->setText(p.illuminant2);
+}
+
+void SettingsDialog::onBrowseCache() {
+    auto folder = QFileDialog::getExistingDirectory(this, tr("Select Cache Folder"));
+    if(!folder.isEmpty())
+        ui->cacheEdit->setText(folder);
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,5 +1,6 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
+#include "SettingsDialog.h"
 
 #include <QDragEnterEvent>
 #include <QDropEvent>
@@ -8,8 +9,14 @@
 #include <QFileInfo>
 #include <QProcess>
 #include <QMessageBox>
-#include <QFileDialog>
+#include <QDesktopServices>
+#include <QUrl>
+#include <QCoreApplication>
 #include <QSettings>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
 #include <algorithm>
 
 #ifdef _WIN32
@@ -56,6 +63,8 @@ MainWindow::MainWindow(QWidget *parent)
     ui->dragAndDropScrollArea->installEventFilter(this);
 
     restoreSettings();
+    loadUniqueNamesFromFile();
+    loadMatrixProfilesFromFile();
 
     // Connect to widgets
     connect(ui->draftModeCheckBox, &QCheckBox::checkStateChanged, this, &MainWindow::onRenderSettingsChanged);
@@ -63,7 +72,11 @@ MainWindow::MainWindow(QWidget *parent)
     connect(ui->scaleRawCheckBox, &QCheckBox::checkStateChanged, this, &MainWindow::onRenderSettingsChanged);
     connect(ui->draftQuality, &QComboBox::currentIndexChanged, this, &MainWindow::onDraftModeQualityChanged);
 
-    connect(ui->changeCacheBtn, &QPushButton::clicked, this, &MainWindow::onSetCacheFolder);
+    connect(ui->actionOptions, &QAction::triggered, this, &MainWindow::onShowOptions);
+    connect(ui->actionUnmountAll, &QAction::triggered, this, &MainWindow::onUnmountAll);
+    connect(ui->actionExit, &QAction::triggered, this, &MainWindow::close);
+    connect(ui->actionDemo, &QAction::triggered, this, &MainWindow::onShowHelp);
+
 }
 
 MainWindow::~MainWindow() {
@@ -80,6 +93,7 @@ void MainWindow::saveSettings() {
     settings.setValue("scaleRaw", ui->scaleRawCheckBox->checkState() == Qt::CheckState::Checked);
     settings.setValue("cachePath", mCacheRootFolder);
     settings.setValue("draftQuality", mDraftQuality);
+    settings.setValue("matrixKey", mCurrentMatrixKey);
 
     // Save mounted files
     settings.beginWriteArray("mountedFiles");
@@ -104,8 +118,9 @@ void MainWindow::restoreSettings() {
     ui->scaleRawCheckBox->setCheckState(
         settings.value("scaleRaw").toBool() ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);
 
-    mCacheRootFolder = settings.value("cachePath").toString();    
+    mCacheRootFolder = settings.value("cachePath").toString();
     mDraftQuality = std::max(1, settings.value("draftQuality").toInt());
+    mCurrentMatrixKey = settings.value("matrixKey").toString();
 
     if(mDraftQuality == 2)
         ui->draftQuality->setCurrentIndex(0);
@@ -301,7 +316,6 @@ void MainWindow::updateUi() {
     else
         ui->scaleRawCheckBox->setEnabled(false);
 
-    ui->cacheFolderLabel->setText(mCacheRootFolder);
 }
 
 void MainWindow::onRenderSettingsChanged(const Qt::CheckState &checkState) {
@@ -327,16 +341,124 @@ void MainWindow::onDraftModeQualityChanged(int index) {
     onRenderSettingsChanged(Qt::CheckState::Checked);
 }
 
-void MainWindow::onSetCacheFolder(bool checked) {
-    Q_UNUSED(checked);  // Parameter not needed for folder selection
-
-    auto folderPath = QFileDialog::getExistingDirectory(
-        this,
-        tr("Select Cache Root Folder"),
-        QString(),  // Start from default location
-        QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks
-    );
-
-    mCacheRootFolder = folderPath;
-    ui->cacheFolderLabel->setText(mCacheRootFolder);
+void MainWindow::onShowOptions() {
+    SettingsDialog dlg(this);
+    dlg.setCachePath(mCacheRootFolder);
+    dlg.setUniqueNames(mUniqueNames);
+    dlg.setMatrixProfiles(mMatrixProfiles);
+    dlg.setCurrentMatrixKey(mCurrentMatrixKey);
+    if(dlg.exec() == QDialog::Accepted) {
+        mCacheRootFolder = dlg.cachePath();
+        mUniqueNames = dlg.uniqueNames();
+        mMatrixProfiles = dlg.matrixProfiles();
+        mCurrentMatrixKey = dlg.currentMatrixKey();
+        saveUniqueNamesToFile();
+        saveMatrixProfilesToFile();
+        saveSettings();
+        auto opts = getRenderOptions(*ui);
+        for(auto& mf : mMountedFiles)
+            mFuseFilesystem->updateOptions(mf.mountId, opts, mDraftQuality);
+    }
 }
+
+void MainWindow::onUnmountAll() {
+    while(!mMountedFiles.isEmpty()) {
+        auto w = mMountedFiles.takeFirst();
+        mFuseFilesystem->unmount(w.mountId);
+    }
+    auto* scrollContent = ui->dragAndDropScrollArea->widget();
+    auto* layout = qobject_cast<QVBoxLayout*>(scrollContent->layout());
+    QLayoutItem* child;
+    while((child = layout->takeAt(0)) != nullptr) {
+        if(auto widget = child->widget()) widget->deleteLater();
+        delete child;
+    }
+    ui->dragAndDropLabel->show();
+}
+
+void MainWindow::onShowHelp() {
+    QDesktopServices::openUrl(QUrl::fromLocalFile(QCoreApplication::applicationDirPath()+"/help/index.html"));
+}
+
+void MainWindow::loadUniqueNamesFromFile() {
+    QFile file(QCoreApplication::applicationDirPath()+"/assets/unique-name.json");
+    if(!file.open(QIODevice::ReadOnly))
+        return;
+    QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    if(!doc.isObject())
+        return;
+    mUniqueNames.clear();
+    for(auto it = doc.object().begin(); it != doc.object().end(); ++it)
+        mUniqueNames.insert(it.key(), it.value().toString());
+    if(!mUniqueNames.isEmpty())
+        mCurrentMatrixKey = mUniqueNames.firstKey();
+}
+
+void MainWindow::loadMatrixProfilesFromFile() {
+    QFile file(QCoreApplication::applicationDirPath()+"/assets/matrix-camera.json");
+    if(!file.open(QIODevice::ReadOnly))
+        return;
+    QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    if(!doc.isObject())
+        return;
+    mMatrixProfiles.clear();
+    for(auto it = doc.object().begin(); it != doc.object().end(); ++it) {
+        MatrixProfile p;
+        QJsonObject obj = it.value().toObject();
+        auto arrayToString = [](const QJsonArray& arr){
+            QStringList list;
+            for(auto v : arr) list << QString::number(v.toDouble());
+            return list.join(",");
+        };
+        p.colorMatrix1 = arrayToString(obj.value("colorMatrix1").toArray());
+        p.colorMatrix2 = arrayToString(obj.value("colorMatrix2").toArray());
+        p.forwardMatrix1 = arrayToString(obj.value("forwardMatrix1").toArray());
+        p.forwardMatrix2 = arrayToString(obj.value("forwardMatrix2").toArray());
+        p.calibrationMatrix1 = arrayToString(obj.value("calibrationMatrix1").toArray());
+        p.calibrationMatrix2 = arrayToString(obj.value("calibrationMatrix2").toArray());
+        p.illuminant1 = obj.value("colorIlluminant1").toString();
+        p.illuminant2 = obj.value("colorIlluminant2").toString();
+        mMatrixProfiles.insert(it.key(), p);
+    }
+    if(!mMatrixProfiles.isEmpty())
+        mCurrentMatrixKey = mMatrixProfiles.firstKey();
+}
+
+void MainWindow::saveUniqueNamesToFile() {
+    QFile file(QCoreApplication::applicationDirPath()+"/assets/unique-name.json");
+    if(!file.open(QIODevice::WriteOnly))
+        return;
+    QJsonObject obj;
+    for(auto it = mUniqueNames.begin(); it != mUniqueNames.end(); ++it)
+        obj.insert(it.key(), it.value());
+    QJsonDocument doc(obj);
+    file.write(doc.toJson());
+}
+
+void MainWindow::saveMatrixProfilesToFile() {
+    QFile file(QCoreApplication::applicationDirPath()+"/assets/matrix-camera.json");
+    if(!file.open(QIODevice::WriteOnly))
+        return;
+    QJsonObject root;
+    auto stringToArray = [](const QString& text){
+        QJsonArray arr;
+        for(const auto& s : text.split(',', Qt::SkipEmptyParts))
+            arr.append(s.toDouble());
+        return arr;
+    };
+    for(auto it = mMatrixProfiles.begin(); it != mMatrixProfiles.end(); ++it) {
+        QJsonObject o;
+        o.insert("colorMatrix1", stringToArray(it.value().colorMatrix1));
+        o.insert("colorMatrix2", stringToArray(it.value().colorMatrix2));
+        o.insert("forwardMatrix1", stringToArray(it.value().forwardMatrix1));
+        o.insert("forwardMatrix2", stringToArray(it.value().forwardMatrix2));
+        o.insert("calibrationMatrix1", stringToArray(it.value().calibrationMatrix1));
+        o.insert("calibrationMatrix2", stringToArray(it.value().calibrationMatrix2));
+        o.insert("colorIlluminant1", it.value().illuminant1);
+        o.insert("colorIlluminant2", it.value().illuminant2);
+        root.insert(it.key(), o);
+    }
+    QJsonDocument doc(root);
+    file.write(doc.toJson());
+}
+

--- a/ui/SettingsDialog.ui
+++ b/ui/SettingsDialog.ui
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SettingsDialog</class>
+ <widget class="QDialog" name="SettingsDialog">
+  <property name="windowTitle">
+   <string>Options</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="cacheLayout">
+     <item>
+      <widget class="QLabel" name="labelCache">
+       <property name="text">
+        <string>Cache Folder:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="cacheEdit"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="browseCacheBtn">
+       <property name="text">
+        <string>Change...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="uniqueTable"/>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="matrixGroup">
+     <property name="title">
+      <string>Matrix Profiles</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelMatrixSet">
+        <property name="text">
+         <string>Matrix Set:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="matrixCombo"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelCM1">
+        <property name="text">
+         <string>ColorMatrix1</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="colorMatrix1Edit"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="labelCM2">
+        <property name="text">
+         <string>ColorMatrix2</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="colorMatrix2Edit"/>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="labelFM1">
+        <property name="text">
+         <string>ForwardMatrix1</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="forwardMatrix1Edit"/>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="labelFM2">
+        <property name="text">
+         <string>ForwardMatrix2</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLineEdit" name="forwardMatrix2Edit"/>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="labelCal1">
+        <property name="text">
+         <string>CalibrationMatrix1</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QLineEdit" name="calibrationMatrix1Edit"/>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="labelCal2">
+        <property name="text">
+         <string>CalibrationMatrix2</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QLineEdit" name="calibrationMatrix2Edit"/>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="labelIll1">
+        <property name="text">
+         <string>Illuminant1</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QLineEdit" name="illuminant1Edit"/>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="labelIll2">
+        <property name="text">
+         <string>Illuminant2</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="QLineEdit" name="illuminant2Edit"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="spacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveBtn">
+       <property name="text">
+        <string>Save</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="cancelBtn">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -11,8 +11,54 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MotionCam FS</string>
-  </property>
+  <string>MotionCam FS</string>
+ </property>
+  <widget class="QMenuBar" name="menubar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>800</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <widget class="QMenu" name="menuFile">
+    <property name="title">
+     <string>File</string>
+    </property>
+    <addaction name="actionUnmountAll"/>
+    <addaction name="actionExit"/>
+   </widget>
+   <widget class="QMenu" name="menuHelp">
+    <property name="title">
+     <string>Help</string>
+    </property>
+    <addaction name="actionDemo"/>
+   </widget>
+   <addaction name="menuFile"/>
+   <addaction name="actionOptions"/>
+   <addaction name="menuHelp"/>
+  </widget>
+  <action name="actionUnmountAll">
+   <property name="text">
+    <string>Unmount All</string>
+   </property>
+  </action>
+  <action name="actionExit">
+   <property name="text">
+    <string>Exit</string>
+   </property>
+  </action>
+  <action name="actionOptions">
+   <property name="text">
+    <string>Options...</string>
+   </property>
+  </action>
+  <action name="actionDemo">
+   <property name="text">
+    <string>Demo</string>
+   </property>
+  </action>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
@@ -90,49 +136,6 @@
           <string>Scale RAW data</string>
          </property>
         </widget>
-       </item>
-       <item row="1" column="0">
-        <layout class="QHBoxLayout" name="cacheLayout">
-         <item>
-          <widget class="QLabel" name="descCacheFolder">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Cache Folder:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="cacheFolderLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>1</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>-</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="changeCacheBtn">
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>30</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Change</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </item>
        <item row="0" column="1">
         <widget class="QCheckBox" name="vignetteCorrectionCheckBox">


### PR DESCRIPTION
## Summary
- add editable matrix and unique name data in Options dialog
- connect Save/Cancel buttons and store cache path
- persist matrix and unique name JSON files
- allow MainWindow to load and save these settings

## Testing
- `cmake -S . -B build` *(fails: Qt not found)*
- `cmake --build build` *(fails: No rule to make target `Makefile`)*

------
https://chatgpt.com/codex/tasks/task_e_684af5c85704832785658717f8b97a83