### PR TITLE
Implement improved Options dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(PROJECT_SOURCES
         src/CameraFrameMetadata.cpp
         src/AudioWriter.cpp
         src/Utils.cpp
+        src/SettingsDialog.cpp
 
         include/mainwindow.h
         include/Types.h
@@ -36,8 +37,11 @@ set(PROJECT_SOURCES
         include/CameraMetadata.h
         include/CameraFrameMetadata.h
         include/Utils.h
+        include/SettingsDialog.h
+        include/MatrixProfile.h
 
         ui/mainwindow.ui
+        ui/SettingsDialog.ui
 )
 
 qt_add_resources(PROJECT_SOURCES resources.qrc)

--- a/assets/camera-name.json
+++ b/assets/camera-name.json
@@ -1,0 +1,6 @@
+{
+  "Blackmagic URSA Mini 4.6K": { "uniqueCameraModel": "Blackmagic URSA Mini 4.6K" },
+  "Panasonic Generic": { "uniqueCameraModel": "Panasonic Generic" },
+  "settings 03": { "uniqueCameraModel": "Panasonic Generic" },
+  "settings 04 expose +3ev": { "uniqueCameraModel": "Sony" }
+}

--- a/assets/matrix-calibration.json
+++ b/assets/matrix-calibration.json
@@ -1,0 +1,21 @@
+{
+  "Matrix Set 1": {
+    "colorMatrix1": [1,0,0,0,1,0,0,0,1],
+    "colorMatrix2": [1,0,0,0,1,0,0,0,1],
+    "forwardMatrix1": [1,0,0,0,1,0,0,0,1],
+    "forwardMatrix2": [1,0,0,0,1,0,0,0,1],
+    "calibrationMatrix1": [0.5234375,0,0,0,1,0,0,0,0.5625],
+    "calibrationMatrix2": [1,0,0,0,1,0,0,0,1],
+    "colorIlluminant2": "standarda",
+    "colorIlluminant1": "d65"
+  },
+  "Matrix Set 2": {
+    "uniqueCameraModel": "Panasonic Generic",
+    "colorMatrix1": [1,0,0,0,1,0,0,0,1],
+    "colorMatrix2": [1,0,0,0,1,0,0,0,1],
+    "forwardMatrix1": [1,0,0,0,1,0,0,0,1],
+    "forwardMatrix2": [1,0,0,0,1,0,0,0,1],
+    "calibrationMatrix1": [0.5234375,0,0,0,1,0,0,0,0.5625],
+    "calibrationMatrix2": [1,0,0,0,1,0,0,0,1]
+  }
+}

--- a/help/index.html
+++ b/help/index.html
@@ -1,0 +1,1 @@
+<html><body><h1>MotionCam FS Demo</h1><p>Demo help page.</p></body></html>

--- a/include/IFuseFileSystem.h
+++ b/include/IFuseFileSystem.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "Types.h"
+#include "MatrixProfile.h"
 
 namespace motioncam {
 
@@ -19,7 +20,14 @@ public:
 
     virtual MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) = 0;
     virtual void unmount(MountId mountId) = 0;
-    virtual void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) = 0;
+    virtual void updateOptions(
+        MountId mountId,
+        FileRenderOptions options,
+        int draftScale,
+        const QMap<QString, QString>& cameraNames,
+        const QString& cameraKey,
+        const QMap<QString, MatrixProfile>& matrixProfiles,
+        const QString& matrixKey) = 0;
 
 protected:
     IFuseFileSystem() = default;

--- a/include/IVirtualFileSystem.h
+++ b/include/IVirtualFileSystem.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "Types.h"
+#include "MatrixProfile.h"
+#include <QMap>
+#include <QString>
 
 #include <optional>
 #include <string>
@@ -26,7 +29,13 @@ public:
         std::function<void(size_t, int)> result,
         bool async) = 0;
 
-    virtual void updateOptions(FileRenderOptions options, int draftScale) = 0;
+    virtual void updateOptions(
+        FileRenderOptions options,
+        int draftScale,
+        const QMap<QString, QString>& cameraNames,
+        const QString& cameraKey,
+        const QMap<QString, MatrixProfile>& matrixProfiles,
+        const QString& matrixKey) = 0;
 
 protected:
     IVirtualFileSystem() = default;

--- a/include/MatrixProfile.h
+++ b/include/MatrixProfile.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <QString>
+
+struct MatrixProfile {
+    QString colorMatrix1;
+    QString colorMatrix2;
+    QString forwardMatrix1;
+    QString forwardMatrix2;
+    QString calibrationMatrix1;
+    QString calibrationMatrix2;
+    QString illuminant1;
+    QString illuminant2;
+    QString uniqueCameraModel;
+};

--- a/include/SettingsDialog.h
+++ b/include/SettingsDialog.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <QDialog>
+#include <QMap>
+#include "MatrixProfile.h"
+
+namespace Ui {
+class SettingsDialog;
+}
+
+
+class SettingsDialog : public QDialog {
+    Q_OBJECT
+public:
+    explicit SettingsDialog(QWidget* parent = nullptr);
+    ~SettingsDialog();
+
+    QString cachePath() const;
+    void setCachePath(const QString& path);
+    QMap<QString, QString> cameraNames() const;
+    void setCameraNames(const QMap<QString, QString>& names);
+    QString currentCameraKey() const;
+    void setCurrentCameraKey(const QString& key);
+    QMap<QString, MatrixProfile> matrixProfiles() const;
+    void setMatrixProfiles(const QMap<QString, MatrixProfile>& profiles);
+    QString currentMatrixKey() const;
+    void setCurrentMatrixKey(const QString& key);
+
+private slots:
+    void onBrowseCache();
+    void onMatrixSetChanged(int index);
+    void onCameraKeyChanged(int index);
+
+private:
+    Ui::SettingsDialog* ui;
+    QMap<QString, MatrixProfile> mMatrixProfiles;
+    QMap<QString, QString> mCameraNames;
+};

--- a/include/VirtualFileSystemImpl_MCRAW.h
+++ b/include/VirtualFileSystemImpl_MCRAW.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <IVirtualFileSystem.h>
+#include <QMap>
+#include <QString>
+#include "MatrixProfile.h"
 
 namespace BS {
 class thread_pool;
@@ -35,7 +38,13 @@ public:
         std::function<void(size_t, int)> result,
         bool async=true) override;
 
-    void updateOptions(FileRenderOptions options, int draftScale) override;
+    void updateOptions(
+        FileRenderOptions options,
+        int draftScale,
+        const QMap<QString, QString>& cameraNames,
+        const QString& cameraKey,
+        const QMap<QString, MatrixProfile>& matrixProfiles,
+        const QString& matrixKey) override;
 
 private:
     void init(FileRenderOptions options);
@@ -68,6 +77,10 @@ private:
     int mDraftScale;
     FileRenderOptions mOptions;
     float mFps;
+    QMap<QString, QString> mCameraNames;
+    QString mCurrentCameraKey;
+    QMap<QString, MatrixProfile> mMatrixProfiles;
+    QString mCurrentMatrixKey;
     std::mutex mMutex;
 };
 

--- a/include/macos/FuseFileSystemImpl_MacOS.h
+++ b/include/macos/FuseFileSystemImpl_MacOS.h
@@ -4,6 +4,9 @@
 #include <memory>
 
 #include "IFuseFileSystem.h"
+#include <QMap>
+#include <QString>
+#include "MatrixProfile.h"
 
 namespace BS {
     class thread_pool;
@@ -22,7 +25,14 @@ public:
 
     MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) override;
     void unmount(MountId mountId) override;
-    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) override;
+    void updateOptions(
+        MountId mountId,
+        FileRenderOptions options,
+        int draftScale,
+        const QMap<QString, QString>& cameraNames,
+        const QString& cameraKey,
+        const QMap<QString, MatrixProfile>& matrixProfiles,
+        const QString& matrixKey) override;
 
 private:
     MountId mNextMountId;

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -6,6 +6,8 @@
 #include <QMainWindow>
 #include <QList>
 #include <QString>
+#include "SettingsDialog.h"
+#include "MatrixProfile.h"
 
 namespace motioncam {
     struct MountedFile {
@@ -65,7 +67,9 @@ protected:
 private slots:
     void onRenderSettingsChanged(const Qt::CheckState &state);
     void onDraftModeQualityChanged(int index);
-    void onSetCacheFolder(bool checked);
+    void onShowOptions();
+    void onUnmountAll();
+    void onShowHelp();
 
     void playFile(const QString& path);
     void removeFile(QWidget* fileWidget);
@@ -74,12 +78,20 @@ private:
     void saveSettings();
     void restoreSettings();
     void updateUi();
+    void loadUniqueNamesFromFile();
+    void loadMatrixProfilesFromFile();
+    void saveUniqueNamesToFile();
+    void saveMatrixProfilesToFile();
 
 private:
     Ui::MainWindow *ui;
     std::unique_ptr<motioncam::IFuseFileSystem> mFuseFilesystem;
     QList<motioncam::MountedFile> mMountedFiles;
     QString mCacheRootFolder;
+    QMap<QString, QString> mUniqueNames;
+    QMap<QString, MatrixProfile> mMatrixProfiles;
+    QString mCurrentCameraKey;
+    QString mCurrentMatrixKey;
     int mDraftQuality;
 };
 

--- a/include/win/FuseFileSystemImpl_Win.h
+++ b/include/win/FuseFileSystemImpl_Win.h
@@ -4,6 +4,9 @@
 #include <memory>
 
 #include "IFuseFileSystem.h"
+#include <QMap>
+#include <QString>
+#include "MatrixProfile.h"
 
 namespace BS {
     class thread_pool;
@@ -21,7 +24,14 @@ public:
 
     MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) override;
     void unmount(MountId mountId) override;
-    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) override;
+    void updateOptions(
+        MountId mountId,
+        FileRenderOptions options,
+        int draftScale,
+        const QMap<QString, QString>& cameraNames,
+        const QString& cameraKey,
+        const QMap<QString, MatrixProfile>& matrixProfiles,
+        const QString& matrixKey) override;
 
 private:
     MountId mNextMountId;

--- a/resources.qrc
+++ b/resources.qrc
@@ -4,5 +4,6 @@
         <file>assets/app_icon.png</file>
         <file>assets/play_btn.png</file>
         <file>assets/remove_btn.png</file>
+        <file>help/index.html</file>
     </qresource>
 </RCC>

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -1,0 +1,119 @@
+#include "SettingsDialog.h"
+#include "ui_SettingsDialog.h"
+
+#include <QFileDialog>
+
+SettingsDialog::SettingsDialog(QWidget* parent) :
+    QDialog(parent), ui(new Ui::SettingsDialog) {
+    ui->setupUi(this);
+    connect(ui->browseCacheBtn, &QPushButton::clicked, this, &SettingsDialog::onBrowseCache);
+    connect(ui->saveBtn, &QPushButton::clicked, this, &SettingsDialog::accept);
+    connect(ui->cancelBtn, &QPushButton::clicked, this, &SettingsDialog::reject);
+    connect(ui->matrixCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsDialog::onMatrixSetChanged);
+    connect(ui->cameraCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsDialog::onCameraKeyChanged);
+}
+
+SettingsDialog::~SettingsDialog() {
+    delete ui;
+}
+
+QString SettingsDialog::cachePath() const {
+    return ui->cacheEdit->text();
+}
+
+void SettingsDialog::setCachePath(const QString& path) {
+    ui->cacheEdit->setText(path);
+}
+
+QMap<QString, QString> SettingsDialog::cameraNames() const {
+    auto names = mCameraNames;
+    auto key = ui->cameraCombo->currentText();
+    if(names.contains(key))
+        names[key] = ui->cameraModelEdit->text();
+    return names;
+}
+
+void SettingsDialog::setCameraNames(const QMap<QString, QString>& names) {
+    mCameraNames = names;
+    ui->cameraCombo->clear();
+    for(auto it = names.begin(); it != names.end(); ++it)
+        ui->cameraCombo->addItem(it.key());
+    if(!names.isEmpty())
+        onCameraKeyChanged(0);
+}
+
+QString SettingsDialog::currentCameraKey() const {
+    return ui->cameraCombo->currentText();
+}
+
+void SettingsDialog::setCurrentCameraKey(const QString& key) {
+    int index = ui->cameraCombo->findText(key);
+    if(index >= 0)
+        ui->cameraCombo->setCurrentIndex(index);
+}
+
+QMap<QString, MatrixProfile> SettingsDialog::matrixProfiles() const {
+    auto profiles = mMatrixProfiles;
+    auto key = ui->matrixCombo->currentText();
+    if(profiles.contains(key)) {
+        auto& p = profiles[key];
+        p.colorMatrix1 = ui->colorMatrix1Edit->text();
+        p.colorMatrix2 = ui->colorMatrix2Edit->text();
+        p.forwardMatrix1 = ui->forwardMatrix1Edit->text();
+        p.forwardMatrix2 = ui->forwardMatrix2Edit->text();
+        p.calibrationMatrix1 = ui->calibrationMatrix1Edit->text();
+        p.calibrationMatrix2 = ui->calibrationMatrix2Edit->text();
+        p.illuminant1 = ui->illuminant1Edit->text();
+        p.illuminant2 = ui->illuminant2Edit->text();
+        p.uniqueCameraModel = mMatrixProfiles[key].uniqueCameraModel;
+    }
+    return profiles;
+}
+
+void SettingsDialog::setMatrixProfiles(const QMap<QString, MatrixProfile>& profiles) {
+    mMatrixProfiles = profiles;
+    ui->matrixCombo->clear();
+    for(auto it = profiles.begin(); it != profiles.end(); ++it)
+        ui->matrixCombo->addItem(it.key());
+    if(!profiles.isEmpty())
+        onMatrixSetChanged(0);
+}
+
+QString SettingsDialog::currentMatrixKey() const {
+    return ui->matrixCombo->currentText();
+}
+
+void SettingsDialog::setCurrentMatrixKey(const QString& key) {
+    int index = ui->matrixCombo->findText(key);
+    if(index >= 0)
+        ui->matrixCombo->setCurrentIndex(index);
+}
+
+void SettingsDialog::onMatrixSetChanged(int index) {
+    Q_UNUSED(index);
+    auto key = ui->matrixCombo->currentText();
+    if(!mMatrixProfiles.contains(key))
+        return;
+    const auto& p = mMatrixProfiles[key];
+    ui->colorMatrix1Edit->setText(p.colorMatrix1);
+    ui->colorMatrix2Edit->setText(p.colorMatrix2);
+    ui->forwardMatrix1Edit->setText(p.forwardMatrix1);
+    ui->forwardMatrix2Edit->setText(p.forwardMatrix2);
+    ui->calibrationMatrix1Edit->setText(p.calibrationMatrix1);
+    ui->calibrationMatrix2Edit->setText(p.calibrationMatrix2);
+    ui->illuminant1Edit->setText(p.illuminant1);
+    ui->illuminant2Edit->setText(p.illuminant2);
+}
+
+void SettingsDialog::onCameraKeyChanged(int index) {
+    Q_UNUSED(index);
+    auto key = ui->cameraCombo->currentText();
+    if(mCameraNames.contains(key))
+        ui->cameraModelEdit->setText(mCameraNames.value(key));
+}
+
+void SettingsDialog::onBrowseCache() {
+    auto folder = QFileDialog::getExistingDirectory(this, tr("Select Cache Folder"));
+    if(!folder.isEmpty())
+        ui->cacheEdit->setText(folder);
+}

--- a/src/VirtualFileSystemImpl_MCRAW.cpp
+++ b/src/VirtualFileSystemImpl_MCRAW.cpp
@@ -4,6 +4,10 @@
 #include "Utils.h"
 #include "AudioWriter.h"
 #include "LRUCache.h"
+#include "MatrixProfile.h"
+
+#include <QMap>
+#include <QString>
 
 #include <motioncam/Decoder.hpp>
 
@@ -194,7 +198,9 @@ VirtualFileSystemImpl_MCRAW::VirtualFileSystemImpl_MCRAW(
         mTypicalDngSize(0),
         mFps(0),
         mDraftScale(draftScale),
-        mOptions(options) {
+        mOptions(options),
+        mCurrentCameraKey(),
+        mCurrentMatrixKey() {
 
     init(options);
 }
@@ -226,6 +232,35 @@ void VirtualFileSystemImpl_MCRAW::init(FileRenderOptions options) {
 
     auto cameraConfig = CameraConfiguration::parse(decoder.getContainerMetadata());
     auto cameraFrameMetadata = CameraFrameMetadata::parse(metadata);
+
+    auto applyOverrides = [this](CameraConfiguration& cfg){
+        if(mMatrixProfiles.contains(mCurrentMatrixKey)) {
+            const auto& p = mMatrixProfiles[mCurrentMatrixKey];
+            auto toArray = [](const QString& text){
+                std::array<float,9> arr{0};
+                auto parts = text.split(',', Qt::SkipEmptyParts);
+                for(int i=0;i<parts.size() && i<9;++i)
+                    arr[i] = parts[i].toFloat();
+                return arr;
+            };
+            cfg.colorMatrix1 = toArray(p.colorMatrix1);
+            cfg.colorMatrix2 = toArray(p.colorMatrix2);
+            cfg.forwardMatrix1 = toArray(p.forwardMatrix1);
+            cfg.forwardMatrix2 = toArray(p.forwardMatrix2);
+            cfg.calibrationMatrix1 = toArray(p.calibrationMatrix1);
+            cfg.calibrationMatrix2 = toArray(p.calibrationMatrix2);
+            if(!p.illuminant1.isEmpty())
+                cfg.colorIlluminant1 = p.illuminant1.toStdString();
+            if(!p.illuminant2.isEmpty())
+                cfg.colorIlluminant2 = p.illuminant2.toStdString();
+            if(!p.uniqueCameraModel.isEmpty())
+                cfg.extraData.postProcessSettings.metadata.buildModel = p.uniqueCameraModel.toStdString();
+        }
+        if(mCameraNames.contains(mCurrentCameraKey))
+            cfg.extraData.postProcessSettings.metadata.buildModel = mCameraNames.value(mCurrentCameraKey).toStdString();
+    };
+
+    applyOverrides(cameraConfig);
 
     auto dngData = utils::generateDng(
         data,
@@ -380,13 +415,40 @@ size_t VirtualFileSystemImpl_MCRAW::generateFrame(
     const auto fps = mFps;
     const auto draftScale = mDraftScale;
 
-    auto generateTask = [&options = mOptions, &cache = mCache, entry, sharableFuture, fps, draftScale, pos, len, dst, result]() {
+    auto generateTask = [this, &options = mOptions, &cache = mCache, entry, sharableFuture, fps, draftScale, pos, len, dst, result]() {
         size_t readBytes = 0;
         int errorCode = -1;
 
         try {
             auto decodedFrame = sharableFuture.get();
             auto [frameIndex, containerMetadata, frameMetadata, frameData] = std::move(decodedFrame);
+            auto applyOverrides = [this](CameraConfiguration& cfg){
+                if(mMatrixProfiles.contains(mCurrentMatrixKey)) {
+                    const auto& p = mMatrixProfiles[mCurrentMatrixKey];
+                    auto toArray = [](const QString& text){
+                        std::array<float,9> arr{0};
+                        auto parts = text.split(',', Qt::SkipEmptyParts);
+                        for(int i=0;i<parts.size() && i<9;++i)
+                            arr[i] = parts[i].toFloat();
+                        return arr;
+                    };
+                    cfg.colorMatrix1 = toArray(p.colorMatrix1);
+                    cfg.colorMatrix2 = toArray(p.colorMatrix2);
+                    cfg.forwardMatrix1 = toArray(p.forwardMatrix1);
+                    cfg.forwardMatrix2 = toArray(p.forwardMatrix2);
+                    cfg.calibrationMatrix1 = toArray(p.calibrationMatrix1);
+                    cfg.calibrationMatrix2 = toArray(p.calibrationMatrix2);
+                    if(!p.illuminant1.isEmpty())
+                        cfg.colorIlluminant1 = p.illuminant1.toStdString();
+                    if(!p.illuminant2.isEmpty())
+                        cfg.colorIlluminant2 = p.illuminant2.toStdString();
+                    if(!p.uniqueCameraModel.isEmpty())
+                        cfg.extraData.postProcessSettings.metadata.buildModel = p.uniqueCameraModel.toStdString();
+                }
+                if(mCameraNames.contains(mCurrentCameraKey))
+                    cfg.extraData.postProcessSettings.metadata.buildModel = mCameraNames.value(mCurrentCameraKey).toStdString();
+            };
+            applyOverrides(containerMetadata);
 
             auto dngData = utils::generateDng(
                 *frameData,
@@ -478,9 +540,19 @@ int VirtualFileSystemImpl_MCRAW::readFile(
     return -1;
 }
 
-void VirtualFileSystemImpl_MCRAW::updateOptions(FileRenderOptions options, int draftScale) {
+void VirtualFileSystemImpl_MCRAW::updateOptions(
+    FileRenderOptions options,
+    int draftScale,
+    const QMap<QString, QString>& cameraNames,
+    const QString& cameraKey,
+    const QMap<QString, MatrixProfile>& matrixProfiles,
+    const QString& matrixKey) {
     mDraftScale = draftScale;
     mOptions = options;
+    mCameraNames = cameraNames;
+    mCurrentCameraKey = cameraKey;
+    mMatrixProfiles = matrixProfiles;
+    mCurrentMatrixKey = matrixKey;
 
     init(options);
 }

--- a/src/macos/FuseFileSystemImpl_MacOS.cpp
+++ b/src/macos/FuseFileSystemImpl_MacOS.cpp
@@ -1,6 +1,10 @@
 #include "macos/FuseFileSystemImpl_MacOS.h"
 #include "VirtualFileSystemImpl_MCRAW.h"
 #include "LRUCache.h"
+#include "MatrixProfile.h"
+
+#include <QMap>
+#include <QString>
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
@@ -73,7 +77,13 @@ public:
     Session(const std::string& srcFile, const std::string& dstPath, VirtualFileSystemImpl_MCRAW* fs);
     ~Session();
 
-    void updateOptions(FileRenderOptions options, int draftScale);
+    void updateOptions(
+        FileRenderOptions options,
+        int draftScale,
+        const QMap<QString, QString>& cameraNames,
+        const QString& cameraKey,
+        const QMap<QString, MatrixProfile>& matrixProfiles,
+        const QString& matrixKey);
 
 private:
     void init(VirtualFileSystemImpl_MCRAW* fs);
@@ -171,8 +181,14 @@ void Session::init(VirtualFileSystemImpl_MCRAW* fs) {
 
 }
 
-void Session::updateOptions(FileRenderOptions options, int draftScale) {
-    mFs->updateOptions(options, draftScale);
+void Session::updateOptions(
+    FileRenderOptions options,
+    int draftScale,
+    const QMap<QString, QString>& cameraNames,
+    const QString& cameraKey,
+    const QMap<QString, MatrixProfile>& matrixProfiles,
+    const QString& matrixKey) {
+    mFs->updateOptions(options, draftScale, cameraNames, cameraKey, matrixProfiles, matrixKey);
 
     fuse_invalidate_path(mFuse, mDstPath.c_str());
 
@@ -408,10 +424,17 @@ void FuseFileSystemImpl_MacOs::unmount(MountId mountId) {
     }
 }
 
-void FuseFileSystemImpl_MacOs::updateOptions(MountId mountId, FileRenderOptions options, int draftScale) {
+void FuseFileSystemImpl_MacOs::updateOptions(
+    MountId mountId,
+    FileRenderOptions options,
+    int draftScale,
+    const QMap<QString, QString>& cameraNames,
+    const QString& cameraKey,
+    const QMap<QString, MatrixProfile>& matrixProfiles,
+    const QString& matrixKey) {
     auto it = mMountedFiles.find(mountId);
     if(it != mMountedFiles.end()) {
-        it->second->updateOptions(options, draftScale);
+        it->second->updateOptions(options, draftScale, cameraNames, cameraKey, matrixProfiles, matrixKey);
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,5 +1,6 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
+#include "SettingsDialog.h"
 
 #include <QDragEnterEvent>
 #include <QDropEvent>
@@ -8,8 +9,14 @@
 #include <QFileInfo>
 #include <QProcess>
 #include <QMessageBox>
-#include <QFileDialog>
+#include <QDesktopServices>
+#include <QUrl>
+#include <QCoreApplication>
 #include <QSettings>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
 #include <algorithm>
 
 #ifdef _WIN32
@@ -56,6 +63,8 @@ MainWindow::MainWindow(QWidget *parent)
     ui->dragAndDropScrollArea->installEventFilter(this);
 
     restoreSettings();
+    loadUniqueNamesFromFile();
+    loadMatrixProfilesFromFile();
 
     // Connect to widgets
     connect(ui->draftModeCheckBox, &QCheckBox::checkStateChanged, this, &MainWindow::onRenderSettingsChanged);
@@ -63,7 +72,11 @@ MainWindow::MainWindow(QWidget *parent)
     connect(ui->scaleRawCheckBox, &QCheckBox::checkStateChanged, this, &MainWindow::onRenderSettingsChanged);
     connect(ui->draftQuality, &QComboBox::currentIndexChanged, this, &MainWindow::onDraftModeQualityChanged);
 
-    connect(ui->changeCacheBtn, &QPushButton::clicked, this, &MainWindow::onSetCacheFolder);
+    connect(ui->actionOptions, &QAction::triggered, this, &MainWindow::onShowOptions);
+    connect(ui->actionUnmountAll, &QAction::triggered, this, &MainWindow::onUnmountAll);
+    connect(ui->actionExit, &QAction::triggered, this, &MainWindow::close);
+    connect(ui->actionDemo, &QAction::triggered, this, &MainWindow::onShowHelp);
+
 }
 
 MainWindow::~MainWindow() {
@@ -80,6 +93,8 @@ void MainWindow::saveSettings() {
     settings.setValue("scaleRaw", ui->scaleRawCheckBox->checkState() == Qt::CheckState::Checked);
     settings.setValue("cachePath", mCacheRootFolder);
     settings.setValue("draftQuality", mDraftQuality);
+    settings.setValue("cameraKey", mCurrentCameraKey);
+    settings.setValue("matrixKey", mCurrentMatrixKey);
 
     // Save mounted files
     settings.beginWriteArray("mountedFiles");
@@ -104,8 +119,10 @@ void MainWindow::restoreSettings() {
     ui->scaleRawCheckBox->setCheckState(
         settings.value("scaleRaw").toBool() ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);
 
-    mCacheRootFolder = settings.value("cachePath").toString();    
+    mCacheRootFolder = settings.value("cachePath").toString();
     mDraftQuality = std::max(1, settings.value("draftQuality").toInt());
+    mCurrentCameraKey = settings.value("cameraKey").toString();
+    mCurrentMatrixKey = settings.value("matrixKey").toString();
 
     if(mDraftQuality == 2)
         ui->draftQuality->setCurrentIndex(0);
@@ -301,7 +318,6 @@ void MainWindow::updateUi() {
     else
         ui->scaleRawCheckBox->setEnabled(false);
 
-    ui->cacheFolderLabel->setText(mCacheRootFolder);
 }
 
 void MainWindow::onRenderSettingsChanged(const Qt::CheckState &checkState) {
@@ -311,7 +327,14 @@ void MainWindow::onRenderSettingsChanged(const Qt::CheckState &checkState) {
     updateUi();
 
     while(it != mMountedFiles.end()) {
-        mFuseFilesystem->updateOptions(it->mountId, renderOptions, mDraftQuality);
+        mFuseFilesystem->updateOptions(
+            it->mountId,
+            renderOptions,
+            mDraftQuality,
+            mUniqueNames,
+            mCurrentCameraKey,
+            mMatrixProfiles,
+            mCurrentMatrixKey);
         ++it;
     }
 }
@@ -327,16 +350,141 @@ void MainWindow::onDraftModeQualityChanged(int index) {
     onRenderSettingsChanged(Qt::CheckState::Checked);
 }
 
-void MainWindow::onSetCacheFolder(bool checked) {
-    Q_UNUSED(checked);  // Parameter not needed for folder selection
-
-    auto folderPath = QFileDialog::getExistingDirectory(
-        this,
-        tr("Select Cache Root Folder"),
-        QString(),  // Start from default location
-        QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks
-    );
-
-    mCacheRootFolder = folderPath;
-    ui->cacheFolderLabel->setText(mCacheRootFolder);
+void MainWindow::onShowOptions() {
+    SettingsDialog dlg(this);
+    dlg.setCachePath(mCacheRootFolder);
+    dlg.setCameraNames(mUniqueNames);
+    dlg.setCurrentCameraKey(mCurrentCameraKey);
+    dlg.setMatrixProfiles(mMatrixProfiles);
+    dlg.setCurrentMatrixKey(mCurrentMatrixKey);
+    if(dlg.exec() == QDialog::Accepted) {
+        mCacheRootFolder = dlg.cachePath();
+        mUniqueNames = dlg.cameraNames();
+        mCurrentCameraKey = dlg.currentCameraKey();
+        mMatrixProfiles = dlg.matrixProfiles();
+        mCurrentMatrixKey = dlg.currentMatrixKey();
+        saveUniqueNamesToFile();
+        saveMatrixProfilesToFile();
+        saveSettings();
+        auto opts = getRenderOptions(*ui);
+        for(auto& mf : mMountedFiles)
+            mFuseFilesystem->updateOptions(
+                mf.mountId,
+                opts,
+                mDraftQuality,
+                mUniqueNames,
+                mCurrentCameraKey,
+                mMatrixProfiles,
+                mCurrentMatrixKey);
+    }
 }
+
+void MainWindow::onUnmountAll() {
+    while(!mMountedFiles.isEmpty()) {
+        auto w = mMountedFiles.takeFirst();
+        mFuseFilesystem->unmount(w.mountId);
+    }
+    auto* scrollContent = ui->dragAndDropScrollArea->widget();
+    auto* layout = qobject_cast<QVBoxLayout*>(scrollContent->layout());
+    QLayoutItem* child;
+    while((child = layout->takeAt(0)) != nullptr) {
+        if(auto widget = child->widget()) widget->deleteLater();
+        delete child;
+    }
+    ui->dragAndDropLabel->show();
+}
+
+void MainWindow::onShowHelp() {
+    QDesktopServices::openUrl(QUrl::fromLocalFile(QCoreApplication::applicationDirPath()+"/help/index.html"));
+}
+
+void MainWindow::loadUniqueNamesFromFile() {
+    QFile file(QCoreApplication::applicationDirPath()+"/assets/camera-name.json");
+    if(!file.open(QIODevice::ReadOnly))
+        return;
+    QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    if(!doc.isObject())
+        return;
+    mUniqueNames.clear();
+    for(auto it = doc.object().begin(); it != doc.object().end(); ++it) {
+        QJsonObject obj = it.value().toObject();
+        mUniqueNames.insert(it.key(), obj.value("uniqueCameraModel").toString());
+    }
+    if(!mUniqueNames.isEmpty())
+        mCurrentCameraKey = mUniqueNames.firstKey();
+}
+
+void MainWindow::loadMatrixProfilesFromFile() {
+    QFile file(QCoreApplication::applicationDirPath()+"/assets/matrix-calibration.json");
+    if(!file.open(QIODevice::ReadOnly))
+        return;
+    QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    if(!doc.isObject())
+        return;
+    mMatrixProfiles.clear();
+    for(auto it = doc.object().begin(); it != doc.object().end(); ++it) {
+        MatrixProfile p;
+        QJsonObject obj = it.value().toObject();
+        auto arrayToString = [](const QJsonArray& arr){
+            QStringList list;
+            for(auto v : arr) list << QString::number(v.toDouble());
+            return list.join(",");
+        };
+        p.colorMatrix1 = arrayToString(obj.value("colorMatrix1").toArray());
+        p.colorMatrix2 = arrayToString(obj.value("colorMatrix2").toArray());
+        p.forwardMatrix1 = arrayToString(obj.value("forwardMatrix1").toArray());
+        p.forwardMatrix2 = arrayToString(obj.value("forwardMatrix2").toArray());
+        p.calibrationMatrix1 = arrayToString(obj.value("calibrationMatrix1").toArray());
+        p.calibrationMatrix2 = arrayToString(obj.value("calibrationMatrix2").toArray());
+        p.illuminant1 = obj.value("colorIlluminant1").toString();
+        p.illuminant2 = obj.value("colorIlluminant2").toString();
+        p.uniqueCameraModel = obj.value("uniqueCameraModel").toString();
+        mMatrixProfiles.insert(it.key(), p);
+    }
+    if(!mMatrixProfiles.isEmpty())
+        mCurrentMatrixKey = mMatrixProfiles.firstKey();
+}
+
+void MainWindow::saveUniqueNamesToFile() {
+    QFile file(QCoreApplication::applicationDirPath()+"/assets/camera-name.json");
+    if(!file.open(QIODevice::WriteOnly))
+        return;
+    QJsonObject obj;
+    for(auto it = mUniqueNames.begin(); it != mUniqueNames.end(); ++it) {
+        QJsonObject inner;
+        inner.insert("uniqueCameraModel", it.value());
+        obj.insert(it.key(), inner);
+    }
+    QJsonDocument doc(obj);
+    file.write(doc.toJson());
+}
+
+void MainWindow::saveMatrixProfilesToFile() {
+    QFile file(QCoreApplication::applicationDirPath()+"/assets/matrix-calibration.json");
+    if(!file.open(QIODevice::WriteOnly))
+        return;
+    QJsonObject root;
+    auto stringToArray = [](const QString& text){
+        QJsonArray arr;
+        for(const auto& s : text.split(',', Qt::SkipEmptyParts))
+            arr.append(s.toDouble());
+        return arr;
+    };
+    for(auto it = mMatrixProfiles.begin(); it != mMatrixProfiles.end(); ++it) {
+        QJsonObject o;
+        o.insert("colorMatrix1", stringToArray(it.value().colorMatrix1));
+        o.insert("colorMatrix2", stringToArray(it.value().colorMatrix2));
+        o.insert("forwardMatrix1", stringToArray(it.value().forwardMatrix1));
+        o.insert("forwardMatrix2", stringToArray(it.value().forwardMatrix2));
+        o.insert("calibrationMatrix1", stringToArray(it.value().calibrationMatrix1));
+        o.insert("calibrationMatrix2", stringToArray(it.value().calibrationMatrix2));
+        o.insert("colorIlluminant1", it.value().illuminant1);
+        o.insert("colorIlluminant2", it.value().illuminant2);
+        if(!it.value().uniqueCameraModel.isEmpty())
+            o.insert("uniqueCameraModel", it.value().uniqueCameraModel);
+        root.insert(it.key(), o);
+    }
+    QJsonDocument doc(root);
+    file.write(doc.toJson());
+}
+

--- a/src/win/FuseFileSystemImpl_Win.cpp
+++ b/src/win/FuseFileSystemImpl_Win.cpp
@@ -4,6 +4,10 @@
 
 #include "VirtualFileSystemImpl_MCRAW.h"
 #include "LRUCache.h"
+#include "MatrixProfile.h"
+
+#include <QMap>
+#include <QString>
 
 #include <iostream>
 #include <ntstatus.h>
@@ -81,7 +85,13 @@ public:
     ~Session();
 
 public:
-    void updateOptions(FileRenderOptions options, int draftScale);
+    void updateOptions(
+        FileRenderOptions options,
+        int draftScale,
+        const QMap<QString, QString>& cameraNames,
+        const QString& cameraKey,
+        const QMap<QString, MatrixProfile>& matrixProfiles,
+        const QString& matrixKey);
 
 protected:
     HRESULT StartDirEnum(_In_ const PRJ_CALLBACK_DATA* CallbackData, _In_ const GUID* EnumerationId) override;
@@ -156,12 +166,18 @@ Session::~Session() {
     Stop();
 }
 
-void Session::updateOptions(FileRenderOptions options, int draftScale) {
+void Session::updateOptions(
+    FileRenderOptions options,
+    int draftScale,
+    const QMap<QString, QString>& cameraNames,
+    const QString& cameraKey,
+    const QMap<QString, MatrixProfile>& matrixProfiles,
+    const QString& matrixKey) {
     mOptions = options;
     mDraftScale = draftScale;
 
     // Tell file system about new options
-    mFs->updateOptions(options, draftScale);
+    mFs->updateOptions(options, draftScale, cameraNames, cameraKey, matrixProfiles, matrixKey);
 
     // We need to clear out the cache
     auto files = mFs->listFiles();
@@ -536,13 +552,20 @@ void FuseFileSystemImpl_Win::unmount(MountId mountId) {
     mMountedFiles.erase(mountId);
 }
 
-void FuseFileSystemImpl_Win::updateOptions(MountId mountId, FileRenderOptions options, int draftScale) {
+void FuseFileSystemImpl_Win::updateOptions(
+    MountId mountId,
+    FileRenderOptions options,
+    int draftScale,
+    const QMap<QString, QString>& cameraNames,
+    const QString& cameraKey,
+    const QMap<QString, MatrixProfile>& matrixProfiles,
+    const QString& matrixKey) {
     auto it = mMountedFiles.find(mountId);
     if(it == mMountedFiles.end())
         return;
 
     dynamic_cast<Session*>(mMountedFiles[mountId].get())->updateOptions(
-        options, draftScale);
+        options, draftScale, cameraNames, cameraKey, matrixProfiles, matrixKey);
 }
 
 } // namespace motioncam

--- a/ui/SettingsDialog.ui
+++ b/ui/SettingsDialog.ui
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SettingsDialog</class>
+ <widget class="QDialog" name="SettingsDialog">
+  <property name="windowTitle">
+   <string>Options</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="cacheLayout">
+     <item>
+      <widget class="QLabel" name="labelCache">
+       <property name="text">
+        <string>Cache Folder:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="cacheEdit"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="browseCacheBtn">
+       <property name="text">
+        <string>Change...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="cameraLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelCameraKey">
+       <property name="text">
+        <string>Camera Key:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="cameraCombo"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelCameraModel">
+       <property name="text">
+        <string>Unique Camera Model:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="cameraModelEdit"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="matrixGroup">
+     <property name="title">
+      <string>Matrix Profiles</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelMatrixSet">
+        <property name="text">
+         <string>Matrix Set:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="matrixCombo"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelCM1">
+        <property name="text">
+         <string>ColorMatrix1</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="colorMatrix1Edit"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="labelCM2">
+        <property name="text">
+         <string>ColorMatrix2</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="colorMatrix2Edit"/>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="labelFM1">
+        <property name="text">
+         <string>ForwardMatrix1</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="forwardMatrix1Edit"/>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="labelFM2">
+        <property name="text">
+         <string>ForwardMatrix2</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLineEdit" name="forwardMatrix2Edit"/>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="labelCal1">
+        <property name="text">
+         <string>CalibrationMatrix1</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QLineEdit" name="calibrationMatrix1Edit"/>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="labelCal2">
+        <property name="text">
+         <string>CalibrationMatrix2</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QLineEdit" name="calibrationMatrix2Edit"/>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="labelIll1">
+        <property name="text">
+         <string>Illuminant1</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QLineEdit" name="illuminant1Edit"/>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="labelIll2">
+        <property name="text">
+         <string>Illuminant2</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="QLineEdit" name="illuminant2Edit"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="spacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveBtn">
+       <property name="text">
+        <string>Save</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="cancelBtn">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -11,8 +11,54 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MotionCam FS</string>
-  </property>
+  <string>MotionCam FS</string>
+ </property>
+  <widget class="QMenuBar" name="menubar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>800</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <widget class="QMenu" name="menuFile">
+    <property name="title">
+     <string>File</string>
+    </property>
+    <addaction name="actionUnmountAll"/>
+    <addaction name="actionExit"/>
+   </widget>
+   <widget class="QMenu" name="menuHelp">
+    <property name="title">
+     <string>Help</string>
+    </property>
+    <addaction name="actionDemo"/>
+   </widget>
+   <addaction name="menuFile"/>
+   <addaction name="actionOptions"/>
+   <addaction name="menuHelp"/>
+  </widget>
+  <action name="actionUnmountAll">
+   <property name="text">
+    <string>Unmount All</string>
+   </property>
+  </action>
+  <action name="actionExit">
+   <property name="text">
+    <string>Exit</string>
+   </property>
+  </action>
+  <action name="actionOptions">
+   <property name="text">
+    <string>Options...</string>
+   </property>
+  </action>
+  <action name="actionDemo">
+   <property name="text">
+    <string>Demo</string>
+   </property>
+  </action>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
@@ -90,49 +136,6 @@
           <string>Scale RAW data</string>
          </property>
         </widget>
-       </item>
-       <item row="1" column="0">
-        <layout class="QHBoxLayout" name="cacheLayout">
-         <item>
-          <widget class="QLabel" name="descCacheFolder">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Cache Folder:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="cacheFolderLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>1</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>-</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="changeCacheBtn">
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>30</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Change</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </item>
        <item row="0" column="1">
         <widget class="QCheckBox" name="vignetteCorrectionCheckBox">


### PR DESCRIPTION
## Summary
- allow editing camera names and matrix sets loaded from JSON files
- rename JSON assets and parse new object format
- update settings persistence for camera key
- adjust UI for selecting camera key and unique name
- extend updateOptions APIs and integrate profile overrides

## Testing
- `cmake -S . -B build` *(fails: Qt not found)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_684af5c85704832785658717f8b97a83