### PR TITLE
Add menu and calibration profile support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(PROJECT_SOURCES
         src/CameraMetadata.cpp
         src/CameraFrameMetadata.cpp
         src/AudioWriter.cpp
+        src/CalibrationProfile.cpp
         src/Utils.cpp
 
         include/mainwindow.h
@@ -31,6 +32,7 @@ set(PROJECT_SOURCES
         include/VirtualFileSystemImpl_MCRAW.h
         include/LRUCache.h
         include/AudioWriter.h
+        include/CalibrationProfile.h
         include/Measure.h
         include/SingleApplication.h
         include/CameraMetadata.h

--- a/include/CalibrationProfile.h
+++ b/include/CalibrationProfile.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <optional>
+#include <array>
+#include <map>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+namespace motioncam {
+
+struct CalibrationProfile {
+    std::optional<std::array<float,9>> colorMatrix1;
+    std::optional<std::array<float,9>> colorMatrix2;
+    std::optional<std::array<float,9>> forwardMatrix1;
+    std::optional<std::array<float,9>> forwardMatrix2;
+    std::optional<std::array<unsigned short,4>> blackLevel;
+    std::optional<float> whiteLevel;
+};
+
+std::map<std::string, CalibrationProfile> loadCalibrationProfiles(const std::string& path);
+
+}

--- a/include/IFuseFileSystem.h
+++ b/include/IFuseFileSystem.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "Types.h"
+#include "CalibrationProfile.h"
 
 namespace motioncam {
 
@@ -17,9 +18,18 @@ public:
     IFuseFileSystem(const IFuseFileSystem&) = delete;
     IFuseFileSystem& operator=(const IFuseFileSystem&) = delete;
 
-    virtual MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) = 0;
+    virtual MountId mount(
+        FileRenderOptions options,
+        int draftScale,
+        const std::string& srcFile,
+        const std::string& dstPath,
+        const CalibrationProfile* profile) = 0;
     virtual void unmount(MountId mountId) = 0;
-    virtual void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) = 0;
+    virtual void updateOptions(
+        MountId mountId,
+        FileRenderOptions options,
+        int draftScale,
+        const CalibrationProfile* profile) = 0;
 
 protected:
     IFuseFileSystem() = default;

--- a/include/IVirtualFileSystem.h
+++ b/include/IVirtualFileSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Types.h"
+#include "CalibrationProfile.h"
 
 #include <optional>
 #include <string>
@@ -26,7 +27,7 @@ public:
         std::function<void(size_t, int)> result,
         bool async) = 0;
 
-    virtual void updateOptions(FileRenderOptions options, int draftScale) = 0;
+    virtual void updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile) = 0;
 
 protected:
     IVirtualFileSystem() = default;

--- a/include/VirtualFileSystemImpl_MCRAW.h
+++ b/include/VirtualFileSystemImpl_MCRAW.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <IVirtualFileSystem.h>
+#include "CalibrationProfile.h"
 
 namespace BS {
 class thread_pool;
@@ -20,7 +21,8 @@ public:
         LRUCache& lruCache,
         FileRenderOptions options,
         int draftScale,
-        const std::string& file);
+        const std::string& file,
+        const CalibrationProfile* profile);
 
     ~VirtualFileSystemImpl_MCRAW();
 
@@ -35,7 +37,7 @@ public:
         std::function<void(size_t, int)> result,
         bool async=true) override;
 
-    void updateOptions(FileRenderOptions options, int draftScale) override;
+    void updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile) override;
 
 private:
     void init(FileRenderOptions options);
@@ -67,6 +69,7 @@ private:
     std::vector<uint8_t> mAudioFile;
     int mDraftScale;
     FileRenderOptions mOptions;
+    const CalibrationProfile* mCalibrationProfile;
     float mFps;
     std::mutex mMutex;
 };

--- a/include/macos/FuseFileSystemImpl_MacOS.h
+++ b/include/macos/FuseFileSystemImpl_MacOS.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "IFuseFileSystem.h"
+#include "CalibrationProfile.h"
 
 namespace BS {
     class thread_pool;
@@ -20,9 +21,9 @@ public:
     FuseFileSystemImpl_MacOs();
     ~FuseFileSystemImpl_MacOs();
 
-    MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) override;
+    MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath, const CalibrationProfile* profile) override;
     void unmount(MountId mountId) override;
-    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) override;
+    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile) override;
 
 private:
     MountId mNextMountId;

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -2,10 +2,12 @@
 #define MAINWINDOW_H
 
 #include "IFuseFileSystem.h"
+#include "CalibrationProfile.h"
 
 #include <QMainWindow>
 #include <QList>
 #include <QString>
+#include <map>
 
 namespace motioncam {
     struct MountedFile {
@@ -66,6 +68,9 @@ private slots:
     void onRenderSettingsChanged(const Qt::CheckState &state);
     void onDraftModeQualityChanged(int index);
     void onSetCacheFolder(bool checked);
+    void onCalibrationChanged(int index);
+    void onUnmountAll();
+    void onExit();
 
     void playFile(const QString& path);
     void removeFile(QWidget* fileWidget);
@@ -81,6 +86,8 @@ private:
     QList<motioncam::MountedFile> mMountedFiles;
     QString mCacheRootFolder;
     int mDraftQuality;
+    std::map<std::string, motioncam::CalibrationProfile> mCalibrationProfiles;
+    QString mSelectedProfile;
 };
 
 #endif // MAINWINDOW_H

--- a/include/win/FuseFileSystemImpl_Win.h
+++ b/include/win/FuseFileSystemImpl_Win.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "IFuseFileSystem.h"
+#include "CalibrationProfile.h"
 
 namespace BS {
     class thread_pool;
@@ -19,9 +20,9 @@ class FuseFileSystemImpl_Win : public IFuseFileSystem
 public:
     FuseFileSystemImpl_Win();
 
-    MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) override;
+    MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath, const CalibrationProfile* profile) override;
     void unmount(MountId mountId) override;
-    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) override;
+    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile) override;
 
 private:
     MountId mNextMountId;

--- a/resources.qrc
+++ b/resources.qrc
@@ -4,5 +4,6 @@
         <file>assets/app_icon.png</file>
         <file>assets/play_btn.png</file>
         <file>assets/remove_btn.png</file>
+        <file>resources/fs-calibration.json</file>
     </qresource>
 </RCC>

--- a/resources/fs-calibration.json
+++ b/resources/fs-calibration.json
@@ -1,0 +1,7 @@
+{
+    "Default": {},
+    "Example": {
+        "colorMatrix1": [1,0,0,0,1,0,0,0,1],
+        "colorMatrix2": [1,0,0,0,1,0,0,0,1]
+    }
+}

--- a/src/CalibrationProfile.cpp
+++ b/src/CalibrationProfile.cpp
@@ -1,0 +1,60 @@
+#include "CalibrationProfile.h"
+#include <fstream>
+#include <QFile>
+#include <QByteArray>
+
+namespace motioncam {
+
+namespace {
+    template<typename T, size_t N>
+    std::optional<std::array<T,N>> parseArray(const nlohmann::json& j) {
+        if(!j.is_array() || j.size() < N)
+            return std::nullopt;
+        std::array<T,N> arr{};
+        for(size_t i=0;i<N && i<j.size();++i)
+            arr[i] = j[i].get<T>();
+        return arr;
+    }
+}
+
+std::map<std::string, CalibrationProfile> loadCalibrationProfiles(const std::string& path) {
+    std::map<std::string, CalibrationProfile> profiles;
+    std::ifstream ifs(path);
+    nlohmann::json j;
+    if(ifs.is_open()) {
+        j = nlohmann::json::parse(ifs, nullptr, false);
+    } else {
+        QFile file(QString::fromStdString(path));
+        if(file.open(QIODevice::ReadOnly)) {
+            QByteArray data = file.readAll();
+            j = nlohmann::json::parse(data.constData(), nullptr, false);
+        } else {
+            return profiles;
+        }
+    }
+    if(!j.is_object())
+        return profiles;
+
+    for(auto it=j.begin(); it!=j.end(); ++it) {
+        CalibrationProfile p;
+        const auto& obj = it.value();
+        if(obj.contains("colorMatrix1"))
+            p.colorMatrix1 = parseArray<float,9>(obj["colorMatrix1"]);
+        if(obj.contains("colorMatrix2"))
+            p.colorMatrix2 = parseArray<float,9>(obj["colorMatrix2"]);
+        if(obj.contains("forwardMatrix1"))
+            p.forwardMatrix1 = parseArray<float,9>(obj["forwardMatrix1"]);
+        if(obj.contains("forwardMatrix2"))
+            p.forwardMatrix2 = parseArray<float,9>(obj["forwardMatrix2"]);
+        if(obj.contains("blackLevel"))
+            p.blackLevel = parseArray<unsigned short,4>(obj["blackLevel"]);
+        if(obj.contains("whiteLevel"))
+            p.whiteLevel = obj["whiteLevel"].get<float>();
+        profiles[it.key()] = p;
+    }
+
+    return profiles;
+}
+
+} // namespace motioncam
+

--- a/src/VirtualFileSystemImpl_MCRAW.cpp
+++ b/src/VirtualFileSystemImpl_MCRAW.cpp
@@ -185,7 +185,8 @@ VirtualFileSystemImpl_MCRAW::VirtualFileSystemImpl_MCRAW(
         LRUCache& lruCache,
         FileRenderOptions options,
         int draftScale,
-        const std::string& file) :
+        const std::string& file,
+        const CalibrationProfile* profile) :
         mCache(lruCache),
         mIoThreadPool(ioThreadPool),
         mProcessingThreadPool(processingThreadPool),
@@ -194,7 +195,8 @@ VirtualFileSystemImpl_MCRAW::VirtualFileSystemImpl_MCRAW(
         mTypicalDngSize(0),
         mFps(0),
         mDraftScale(draftScale),
-        mOptions(options) {
+        mOptions(options),
+        mCalibrationProfile(profile) {
 
     init(options);
 }
@@ -380,13 +382,29 @@ size_t VirtualFileSystemImpl_MCRAW::generateFrame(
     const auto fps = mFps;
     const auto draftScale = mDraftScale;
 
-    auto generateTask = [&options = mOptions, &cache = mCache, entry, sharableFuture, fps, draftScale, pos, len, dst, result]() {
+    const auto profile = mCalibrationProfile;
+    auto generateTask = [&options = mOptions, &cache = mCache, entry, sharableFuture, fps, draftScale, pos, len, dst, result, profile]() {
         size_t readBytes = 0;
         int errorCode = -1;
 
         try {
             auto decodedFrame = sharableFuture.get();
             auto [frameIndex, containerMetadata, frameMetadata, frameData] = std::move(decodedFrame);
+
+            if(profile) {
+                if(profile->colorMatrix1)
+                    containerMetadata.colorMatrix1 = *profile->colorMatrix1;
+                if(profile->colorMatrix2)
+                    containerMetadata.colorMatrix2 = *profile->colorMatrix2;
+                if(profile->forwardMatrix1)
+                    containerMetadata.forwardMatrix1 = *profile->forwardMatrix1;
+                if(profile->forwardMatrix2)
+                    containerMetadata.forwardMatrix2 = *profile->forwardMatrix2;
+                if(profile->blackLevel)
+                    containerMetadata.blackLevel = *profile->blackLevel;
+                if(profile->whiteLevel)
+                    containerMetadata.whiteLevel = *profile->whiteLevel;
+            }
 
             auto dngData = utils::generateDng(
                 *frameData,
@@ -478,9 +496,10 @@ int VirtualFileSystemImpl_MCRAW::readFile(
     return -1;
 }
 
-void VirtualFileSystemImpl_MCRAW::updateOptions(FileRenderOptions options, int draftScale) {
+void VirtualFileSystemImpl_MCRAW::updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile) {
     mDraftScale = draftScale;
     mOptions = options;
+    mCalibrationProfile = profile;
 
     init(options);
 }

--- a/src/macos/FuseFileSystemImpl_MacOS.cpp
+++ b/src/macos/FuseFileSystemImpl_MacOS.cpp
@@ -73,7 +73,7 @@ public:
     Session(const std::string& srcFile, const std::string& dstPath, VirtualFileSystemImpl_MCRAW* fs);
     ~Session();
 
-    void updateOptions(FileRenderOptions options, int draftScale);
+    void updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile);
 
 private:
     void init(VirtualFileSystemImpl_MCRAW* fs);
@@ -171,8 +171,8 @@ void Session::init(VirtualFileSystemImpl_MCRAW* fs) {
 
 }
 
-void Session::updateOptions(FileRenderOptions options, int draftScale) {
-    mFs->updateOptions(options, draftScale);
+void Session::updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile) {
+    mFs->updateOptions(options, draftScale, profile);
 
     fuse_invalidate_path(mFuse, mDstPath.c_str());
 
@@ -344,7 +344,7 @@ FuseFileSystemImpl_MacOs::~FuseFileSystemImpl_MacOs() {
 }
 
 MountId FuseFileSystemImpl_MacOs::mount(
-    FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath)
+    FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath, const CalibrationProfile* profile)
 {
     fs::path srcPath(srcFile);
     std::string extension = srcPath.extension().string();
@@ -376,7 +376,8 @@ MountId FuseFileSystemImpl_MacOs::mount(
                     *mCache,
                     options,
                     draftScale,
-                    srcFile);
+                    srcFile,
+                    profile);
 
             auto session = std::make_unique<Session>(srcFile, dstPath, fs);
 
@@ -408,10 +409,10 @@ void FuseFileSystemImpl_MacOs::unmount(MountId mountId) {
     }
 }
 
-void FuseFileSystemImpl_MacOs::updateOptions(MountId mountId, FileRenderOptions options, int draftScale) {
+void FuseFileSystemImpl_MacOs::updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile) {
     auto it = mMountedFiles.find(mountId);
     if(it != mMountedFiles.end()) {
-        it->second->updateOptions(options, draftScale);
+        it->second->updateOptions(options, draftScale, profile);
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -10,7 +10,9 @@
 #include <QMessageBox>
 #include <QFileDialog>
 #include <QSettings>
+#include <QVBoxLayout>
 #include <algorithm>
+#include "CalibrationProfile.h"
 
 #ifdef _WIN32
 #include "win/FuseFileSystemImpl_Win.h"
@@ -55,6 +57,26 @@ MainWindow::MainWindow(QWidget *parent)
     ui->dragAndDropScrollArea->setAcceptDrops(true);
     ui->dragAndDropScrollArea->installEventFilter(this);
 
+    mCalibrationProfiles = loadCalibrationProfiles("resources/fs-calibration.json");
+    if(!mCalibrationProfiles.empty() && mSelectedProfile.isEmpty())
+        mSelectedProfile = QString::fromStdString(mCalibrationProfiles.begin()->first);
+    for(const auto& p : mCalibrationProfiles) {
+        ui->calibrationCombo->addItem(QString::fromStdString(p.first));
+        auto act = ui->menuCalibration->addAction(QString::fromStdString(p.first));
+        act->setCheckable(true);
+        connect(act, &QAction::triggered, this, [this, act]() {
+            int idx = ui->calibrationCombo->findText(act->text());
+            if(idx >= 0) ui->calibrationCombo->setCurrentIndex(idx);
+        });
+    }
+    connect(ui->calibrationCombo, &QComboBox::currentIndexChanged, this, &MainWindow::onCalibrationChanged);
+
+    connect(ui->actionUnmountAll, &QAction::triggered, this, &MainWindow::onUnmountAll);
+    connect(ui->actionExit, &QAction::triggered, this, &MainWindow::onExit);
+    connect(ui->actionChangeCacheFolder, &QAction::triggered, this, [this]{ onSetCacheFolder(false); });
+    connect(ui->actionScaleRaw, &QAction::toggled, ui->scaleRawCheckBox, &QCheckBox::setChecked);
+    connect(ui->scaleRawCheckBox, &QCheckBox::toggled, ui->actionScaleRaw, &QAction::setChecked);
+
     restoreSettings();
 
     // Connect to widgets
@@ -80,6 +102,7 @@ void MainWindow::saveSettings() {
     settings.setValue("scaleRaw", ui->scaleRawCheckBox->checkState() == Qt::CheckState::Checked);
     settings.setValue("cachePath", mCacheRootFolder);
     settings.setValue("draftQuality", mDraftQuality);
+    settings.setValue("calibrationProfile", mSelectedProfile);
 
     // Save mounted files
     settings.beginWriteArray("mountedFiles");
@@ -104,8 +127,12 @@ void MainWindow::restoreSettings() {
     ui->scaleRawCheckBox->setCheckState(
         settings.value("scaleRaw").toBool() ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);
 
-    mCacheRootFolder = settings.value("cachePath").toString();    
+    mCacheRootFolder = settings.value("cachePath").toString();
     mDraftQuality = std::max(1, settings.value("draftQuality").toInt());
+    mSelectedProfile = settings.value("calibrationProfile", mSelectedProfile).toString();
+    int profIndex = ui->calibrationCombo->findText(mSelectedProfile);
+    if(profIndex >= 0)
+        ui->calibrationCombo->setCurrentIndex(profIndex);
 
     if(mDraftQuality == 2)
         ui->draftQuality->setCurrentIndex(0);
@@ -181,8 +208,13 @@ void MainWindow::mountFile(const QString& filePath) {
     motioncam::MountId mountId;
 
     try {
+        auto profileName = ui->calibrationCombo->currentText().toStdString();
+        const CalibrationProfile* profile = nullptr;
+        auto itProf = mCalibrationProfiles.find(profileName);
+        if(itProf != mCalibrationProfiles.end())
+            profile = &itProf->second;
         mountId = mFuseFilesystem->mount(
-            getRenderOptions(*ui), mDraftQuality, filePath.toStdString(), dstPath.toStdString());
+            getRenderOptions(*ui), mDraftQuality, filePath.toStdString(), dstPath.toStdString(), profile);
     }
     catch(std::runtime_error& e) {
         QMessageBox::critical(this, "Error", QString("There was an error mounting the file. (error: %1)").arg(e.what()));
@@ -302,6 +334,10 @@ void MainWindow::updateUi() {
         ui->scaleRawCheckBox->setEnabled(false);
 
     ui->cacheFolderLabel->setText(mCacheRootFolder);
+
+    for(auto act : ui->menuCalibration->actions())
+        act->setChecked(act->text() == mSelectedProfile);
+    ui->actionScaleRaw->setChecked(ui->scaleRawCheckBox->isChecked());
 }
 
 void MainWindow::onRenderSettingsChanged(const Qt::CheckState &checkState) {
@@ -311,7 +347,11 @@ void MainWindow::onRenderSettingsChanged(const Qt::CheckState &checkState) {
     updateUi();
 
     while(it != mMountedFiles.end()) {
-        mFuseFilesystem->updateOptions(it->mountId, renderOptions, mDraftQuality);
+        const CalibrationProfile* profile = nullptr;
+        auto itProf = mCalibrationProfiles.find(mSelectedProfile.toStdString());
+        if(itProf != mCalibrationProfiles.end())
+            profile = &itProf->second;
+        mFuseFilesystem->updateOptions(it->mountId, renderOptions, mDraftQuality, profile);
         ++it;
     }
 }
@@ -339,4 +379,31 @@ void MainWindow::onSetCacheFolder(bool checked) {
 
     mCacheRootFolder = folderPath;
     ui->cacheFolderLabel->setText(mCacheRootFolder);
+}
+
+void MainWindow::onCalibrationChanged(int index) {
+    Q_UNUSED(index);
+    mSelectedProfile = ui->calibrationCombo->currentText();
+    onRenderSettingsChanged(Qt::CheckState::Checked);
+}
+
+void MainWindow::onUnmountAll() {
+    auto* scrollContent = ui->dragAndDropScrollArea->widget();
+    auto* scrollLayout = qobject_cast<QVBoxLayout*>(scrollContent->layout());
+    while(!mMountedFiles.empty()) {
+        auto mountId = mMountedFiles.front().mountId;
+        mFuseFilesystem->unmount(mountId);
+        mMountedFiles.pop_front();
+    }
+    QLayoutItem* child;
+    while((child = scrollLayout->takeAt(0)) != nullptr) {
+        if(child->widget())
+            child->widget()->deleteLater();
+        delete child;
+    }
+    ui->dragAndDropLabel->show();
+}
+
+void MainWindow::onExit() {
+    close();
 }

--- a/src/win/FuseFileSystemImpl_Win.cpp
+++ b/src/win/FuseFileSystemImpl_Win.cpp
@@ -81,7 +81,7 @@ public:
     ~Session();
 
 public:
-    void updateOptions(FileRenderOptions options, int draftScale);
+    void updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile);
 
 protected:
     HRESULT StartDirEnum(_In_ const PRJ_CALLBACK_DATA* CallbackData, _In_ const GUID* EnumerationId) override;
@@ -156,12 +156,12 @@ Session::~Session() {
     Stop();
 }
 
-void Session::updateOptions(FileRenderOptions options, int draftScale) {
+void Session::updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile) {
     mOptions = options;
     mDraftScale = draftScale;
 
     // Tell file system about new options
-    mFs->updateOptions(options, draftScale);
+    mFs->updateOptions(options, draftScale, profile);
 
     // We need to clear out the cache
     auto files = mFs->listFiles();
@@ -504,7 +504,7 @@ FuseFileSystemImpl_Win::FuseFileSystemImpl_Win() :
     setupLogging();
 }
 
-MountId FuseFileSystemImpl_Win::mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) {
+MountId FuseFileSystemImpl_Win::mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath, const CalibrationProfile* profile) {
     fs::path srcPath(srcFile);
     std::string extension = srcPath.extension().string();
 
@@ -514,7 +514,7 @@ MountId FuseFileSystemImpl_Win::mount(FileRenderOptions options, int draftScale,
         auto mountId = mNextMountId++;
 
         try {
-            auto fs = std::make_unique<VirtualFileSystemImpl_MCRAW>(*mIoThreadPool, *mProcessingThreadPool, *mCache, options, draftScale, srcFile);
+            auto fs = std::make_unique<VirtualFileSystemImpl_MCRAW>(*mIoThreadPool, *mProcessingThreadPool, *mCache, options, draftScale, srcFile, profile);
 
             mMountedFiles[mountId] = std::make_unique<Session>(dstPath, std::move(fs));
         }
@@ -536,13 +536,13 @@ void FuseFileSystemImpl_Win::unmount(MountId mountId) {
     mMountedFiles.erase(mountId);
 }
 
-void FuseFileSystemImpl_Win::updateOptions(MountId mountId, FileRenderOptions options, int draftScale) {
+void FuseFileSystemImpl_Win::updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile) {
     auto it = mMountedFiles.find(mountId);
     if(it == mMountedFiles.end())
         return;
 
     dynamic_cast<Session*>(mMountedFiles[mountId].get())->updateOptions(
-        options, draftScale);
+        options, draftScale, profile);
 }
 
 } // namespace motioncam

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -135,14 +135,24 @@
         </layout>
        </item>
        <item row="0" column="1">
-        <widget class="QCheckBox" name="vignetteCorrectionCheckBox">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
+       <widget class="QCheckBox" name="vignetteCorrectionCheckBox">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Apply vignette correction</string>
+        </property>
+       </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLabel" name="descCalibration">
          <property name="text">
-          <string>Apply vignette correction</string>
+          <string>Calibration:</string>
          </property>
         </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="QComboBox" name="calibrationCombo"/>
        </item>
        <item row="0" column="0">
         <layout class="QHBoxLayout" name="draftLayout">
@@ -191,6 +201,62 @@
     </item>
    </layout>
   </widget>
+  <widget class="QMenuBar" name="menubar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>800</width>
+     <height>22</height>
+    </rect>
+   </property>
+   <widget class="QMenu" name="menuFile">
+    <property name="title">
+     <string>&amp;File</string>
+    </property>
+    <addaction name="actionUnmountAll"/>
+    <addaction name="actionExit"/>
+   </widget>
+   <widget class="QMenu" name="menuOptions">
+    <property name="title">
+     <string>&amp;Options</string>
+    </property>
+    <addaction name="actionChangeCacheFolder"/>
+    <addaction name="actionScaleRaw"/>
+    <addaction name="menuCalibration"/>
+   </widget>
+   <widget class="QMenu" name="menuCalibration">
+    <property name="title">
+     <string>Calibration</string>
+    </property>
+   </widget>
+   <addaction name="menuFile"/>
+   <addaction name="menuOptions"/>
+  </widget>
+  <widget class="QStatusBar" name="statusbar"/>
+  <action name="actionUnmountAll">
+   <property name="text">
+    <string>Unmount All</string>
+   </property>
+  </action>
+  <action name="actionExit">
+   <property name="text">
+    <string>Exit</string>
+   </property>
+  </action>
+  <action name="actionChangeCacheFolder">
+   <property name="text">
+    <string>Change Cache Folder</string>
+   </property>
+  </action>
+  <action name="actionScaleRaw">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Scale RAW</string>
+   </property>
+  </action>
  </widget>
  <resources/>
  <connections/>


### PR DESCRIPTION
## Summary
- add `CalibrationProfile` type and loader
- integrate calibration profile selection in VirtualFileSystemImpl
- expose calibration selection in MainWindow with menu and combo box
- adjust IFuseFileSystem and VirtualFileSystem APIs for calibration profiles
- hook up new menu actions and add file menu to UI

## Testing
- `cmake -S . -B build && cmake --build build` *(fails: Could not find a package configuration file provided by "QT" )*


------
https://chatgpt.com/codex/tasks/task_e_684b281f4a28832786abcf966dc645e4