### PR TITLE
Add calibration options and menu features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,12 +27,14 @@ set(PROJECT_SOURCES
         src/CameraFrameMetadata.cpp
         src/AudioWriter.cpp
         src/Utils.cpp
+        src/CalibrationProfile.cpp
 
         include/mainwindow.h
         include/Types.h
         include/IVirtualFileSystem.h
         include/IFuseFileSystem.h
         include/VirtualFileSystemImpl_MCRAW.h
+        include/CalibrationProfile.h
         include/LRUCache.h
         include/AudioWriter.h
         include/Measure.h

--- a/include/CalibrationProfile.h
+++ b/include/CalibrationProfile.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <array>
+#include <string>
+#include <map>
+
+#include <nlohmann/json.hpp>
+
+namespace motioncam {
+
+struct CalibrationProfile {
+    std::string uniqueCameraModel;
+    std::array<float, 9> colorMatrix1{};
+    std::array<float, 9> colorMatrix2{};
+    std::array<float, 9> forwardMatrix1{};
+    std::array<float, 9> forwardMatrix2{};
+    std::array<float, 9> calibrationMatrix1{};
+    std::array<float, 9> calibrationMatrix2{};
+    std::string colorIlluminant1;
+    std::string colorIlluminant2;
+    float baselineExposure{0.f};
+};
+
+std::map<std::string, CalibrationProfile> loadCalibrationProfiles(const std::string& path);
+
+} // namespace motioncam
+

--- a/include/IFuseFileSystem.h
+++ b/include/IFuseFileSystem.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "Types.h"
+#include "CalibrationProfile.h"
 
 namespace motioncam {
 
@@ -19,7 +20,7 @@ public:
 
     virtual MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) = 0;
     virtual void unmount(MountId mountId) = 0;
-    virtual void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) = 0;
+    virtual void updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile) = 0;
 
 protected:
     IFuseFileSystem() = default;

--- a/include/IVirtualFileSystem.h
+++ b/include/IVirtualFileSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Types.h"
+#include "CalibrationProfile.h"
 
 #include <optional>
 #include <string>
@@ -26,7 +27,7 @@ public:
         std::function<void(size_t, int)> result,
         bool async) = 0;
 
-    virtual void updateOptions(FileRenderOptions options, int draftScale) = 0;
+    virtual void updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile) = 0;
 
 protected:
     IVirtualFileSystem() = default;

--- a/include/VirtualFileSystemImpl_MCRAW.h
+++ b/include/VirtualFileSystemImpl_MCRAW.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <IVirtualFileSystem.h>
+#include "CalibrationProfile.h"
 
 namespace BS {
 class thread_pool;
@@ -35,7 +36,7 @@ public:
         std::function<void(size_t, int)> result,
         bool async=true) override;
 
-    void updateOptions(FileRenderOptions options, int draftScale) override;
+    void updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile) override;
 
 private:
     void init(FileRenderOptions options);
@@ -69,6 +70,7 @@ private:
     FileRenderOptions mOptions;
     float mFps;
     std::mutex mMutex;
+    const CalibrationProfile* mCalibration;
 };
 
 } // namespace motioncam

--- a/include/macos/FuseFileSystemImpl_MacOS.h
+++ b/include/macos/FuseFileSystemImpl_MacOS.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "IFuseFileSystem.h"
+#include "../CalibrationProfile.h"
 
 namespace BS {
     class thread_pool;
@@ -22,7 +23,7 @@ public:
 
     MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) override;
     void unmount(MountId mountId) override;
-    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) override;
+    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile) override;
 
 private:
     MountId mNextMountId;

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -6,6 +6,8 @@
 #include <QMainWindow>
 #include <QList>
 #include <QString>
+#include <map>
+#include "CalibrationProfile.h"
 
 namespace motioncam {
     struct MountedFile {
@@ -66,6 +68,9 @@ private slots:
     void onRenderSettingsChanged(const Qt::CheckState &state);
     void onDraftModeQualityChanged(int index);
     void onSetCacheFolder(bool checked);
+    void onCalibrationProfileChanged(int index);
+    void onUnmountAll();
+    void onAdvancedOptions();
 
     void playFile(const QString& path);
     void removeFile(QWidget* fileWidget);
@@ -74,6 +79,7 @@ private:
     void saveSettings();
     void restoreSettings();
     void updateUi();
+    void applyCalibration();
 
 private:
     Ui::MainWindow *ui;
@@ -81,6 +87,9 @@ private:
     QList<motioncam::MountedFile> mMountedFiles;
     QString mCacheRootFolder;
     int mDraftQuality;
+    std::map<std::string, motioncam::CalibrationProfile> mCalibrationProfiles;
+    QString mCalibrationFile;
+    QString mSelectedProfile;
 };
 
 #endif // MAINWINDOW_H

--- a/include/win/FuseFileSystemImpl_Win.h
+++ b/include/win/FuseFileSystemImpl_Win.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "IFuseFileSystem.h"
+#include "../CalibrationProfile.h"
 
 namespace BS {
     class thread_pool;
@@ -21,7 +22,7 @@ public:
 
     MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) override;
     void unmount(MountId mountId) override;
-    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) override;
+    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile) override;
 
 private:
     MountId mNextMountId;

--- a/src/CalibrationProfile.cpp
+++ b/src/CalibrationProfile.cpp
@@ -1,0 +1,44 @@
+#include "CalibrationProfile.h"
+
+#include <fstream>
+#include <stdexcept>
+
+namespace motioncam {
+
+static std::array<float,9> toArray(const nlohmann::json& j) {
+    std::array<float,9> a{};
+    for(size_t i=0;i<9 && i<j.size();++i)
+        a[i] = j[i].get<float>();
+    return a;
+}
+
+std::map<std::string, CalibrationProfile> loadCalibrationProfiles(const std::string& path) {
+    std::ifstream f(path);
+    if(!f.is_open())
+        throw std::runtime_error("Failed to open calibration file");
+
+    nlohmann::json j;
+    f >> j;
+
+    std::map<std::string, CalibrationProfile> profiles;
+    for(auto it=j.begin(); it!=j.end(); ++it) {
+        CalibrationProfile p;
+        const auto& obj = it.value();
+        p.uniqueCameraModel = obj.value("uniqueCameraModel", "");
+        if(obj.contains("colorMatrix1")) p.colorMatrix1 = toArray(obj["colorMatrix1"]);
+        if(obj.contains("colorMatrix2")) p.colorMatrix2 = toArray(obj["colorMatrix2"]);
+        if(obj.contains("forwardMatrix1")) p.forwardMatrix1 = toArray(obj["forwardMatrix1"]);
+        if(obj.contains("forwardMatrix2")) p.forwardMatrix2 = toArray(obj["forwardMatrix2"]);
+        if(obj.contains("calibrationMatrix1")) p.calibrationMatrix1 = toArray(obj["calibrationMatrix1"]);
+        if(obj.contains("calibrationMatrix2")) p.calibrationMatrix2 = toArray(obj["calibrationMatrix2"]);
+        p.colorIlluminant1 = obj.value("colorIlluminant1", "");
+        p.colorIlluminant2 = obj.value("colorIlluminant2", "");
+        p.baselineExposure = obj.value("baselineExposure", 0.f);
+        profiles[it.key()] = p;
+    }
+
+    return profiles;
+}
+
+} // namespace motioncam
+

--- a/src/VirtualFileSystemImpl_MCRAW.cpp
+++ b/src/VirtualFileSystemImpl_MCRAW.cpp
@@ -194,7 +194,8 @@ VirtualFileSystemImpl_MCRAW::VirtualFileSystemImpl_MCRAW(
         mTypicalDngSize(0),
         mFps(0),
         mDraftScale(draftScale),
-        mOptions(options) {
+        mOptions(options),
+        mCalibration(nullptr) {
 
     init(options);
 }
@@ -383,7 +384,7 @@ size_t VirtualFileSystemImpl_MCRAW::generateFrame(
     const auto fps = mFps;
     const auto draftScale = mDraftScale;
 
-    auto generateTask = [&options = mOptions, &cache = mCache, entry, sharableFuture, fps, draftScale, pos, len, dst, result]() {
+    auto generateTask = [this, &options = mOptions, &cache = mCache, entry, sharableFuture, fps, draftScale, pos, len, dst, result]() {
         size_t readBytes = 0;
         int errorCode = -1;
 
@@ -392,6 +393,17 @@ size_t VirtualFileSystemImpl_MCRAW::generateFrame(
             auto [frameIndex, containerMetadata, frameMetadata, frameData] = std::move(decodedFrame);
 
             spdlog::debug("Generating {}", entry.name);
+
+            if(this->mCalibration) {
+                containerMetadata.colorMatrix1 = this->mCalibration->colorMatrix1;
+                containerMetadata.colorMatrix2 = this->mCalibration->colorMatrix2;
+                containerMetadata.forwardMatrix1 = this->mCalibration->forwardMatrix1;
+                containerMetadata.forwardMatrix2 = this->mCalibration->forwardMatrix2;
+                containerMetadata.calibrationMatrix1 = this->mCalibration->calibrationMatrix1;
+                containerMetadata.calibrationMatrix2 = this->mCalibration->calibrationMatrix2;
+                containerMetadata.colorIlluminant1 = this->mCalibration->colorIlluminant1;
+                containerMetadata.colorIlluminant2 = this->mCalibration->colorIlluminant2;
+            }
 
             auto dngData = utils::generateDng(
                 *frameData,
@@ -484,9 +496,10 @@ int VirtualFileSystemImpl_MCRAW::readFile(
     return -1;
 }
 
-void VirtualFileSystemImpl_MCRAW::updateOptions(FileRenderOptions options, int draftScale) {
+void VirtualFileSystemImpl_MCRAW::updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile) {
     mDraftScale = draftScale;
     mOptions = options;
+    mCalibration = profile;
 
     init(options);
 }

--- a/src/macos/FuseFileSystemImpl_MacOS.cpp
+++ b/src/macos/FuseFileSystemImpl_MacOS.cpp
@@ -73,7 +73,7 @@ public:
     Session(const std::string& srcFile, const std::string& dstPath, VirtualFileSystemImpl_MCRAW* fs);
     ~Session();
 
-    void updateOptions(FileRenderOptions options, int draftScale);
+    void updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile);
 
 private:
     void init(VirtualFileSystemImpl_MCRAW* fs);
@@ -176,8 +176,8 @@ void Session::init(VirtualFileSystemImpl_MCRAW* fs) {
 
 }
 
-void Session::updateOptions(FileRenderOptions options, int draftScale) {
-    mFs->updateOptions(options, draftScale);
+void Session::updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile) {
+    mFs->updateOptions(options, draftScale, profile);
 
     fuse_invalidate_path(mFuse, mDstPath.c_str());
 
@@ -415,10 +415,10 @@ void FuseFileSystemImpl_MacOs::unmount(MountId mountId) {
     }
 }
 
-void FuseFileSystemImpl_MacOs::updateOptions(MountId mountId, FileRenderOptions options, int draftScale) {
+void FuseFileSystemImpl_MacOs::updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile) {
     auto it = mMountedFiles.find(mountId);
     if(it != mMountedFiles.end()) {
-        it->second->updateOptions(options, draftScale);
+        it->second->updateOptions(options, draftScale, profile);
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -10,6 +10,10 @@
 #include <QMessageBox>
 #include <QFileDialog>
 #include <QSettings>
+#include <QMenuBar>
+#include <QAction>
+#include "CalibrationProfile.h"
+#include <QVBoxLayout>
 #include <algorithm>
 
 #ifdef _WIN32
@@ -45,6 +49,23 @@ MainWindow::MainWindow(QWidget *parent)
 {
     ui->setupUi(this);
 
+    // Create menu bar
+    auto fileMenu = menuBar()->addMenu("&File");
+    auto unmountAction = fileMenu->addAction("Unmount All");
+    auto exitAction = fileMenu->addAction("Exit");
+    connect(unmountAction, &QAction::triggered, this, &MainWindow::onUnmountAll);
+    connect(exitAction, &QAction::triggered, this, &MainWindow::close);
+
+    auto advMenu = menuBar()->addMenu("&Advanced");
+    auto optionsAction = advMenu->addAction("Options...");
+    connect(optionsAction, &QAction::triggered, this, &MainWindow::onAdvancedOptions);
+
+    auto helpMenu = menuBar()->addMenu("&Help");
+    auto aboutAction = helpMenu->addAction("About");
+    connect(aboutAction, &QAction::triggered, [this]() {
+        QMessageBox::about(this, tr("About"), tr("MotionCam FS"));
+    });
+
 #ifdef _WIN32
     mFuseFilesystem = std::make_unique<motioncam::FuseFileSystemImpl_Win>();
 #elif __APPLE__
@@ -62,6 +83,8 @@ MainWindow::MainWindow(QWidget *parent)
     connect(ui->vignetteCorrectionCheckBox, &QCheckBox::checkStateChanged, this, &MainWindow::onRenderSettingsChanged);
     connect(ui->scaleRawCheckBox, &QCheckBox::checkStateChanged, this, &MainWindow::onRenderSettingsChanged);
     connect(ui->draftQuality, &QComboBox::currentIndexChanged, this, &MainWindow::onDraftModeQualityChanged);
+    if(ui->calibrationProfileCombo)
+        connect(ui->calibrationProfileCombo, &QComboBox::currentIndexChanged, this, &MainWindow::onCalibrationProfileChanged);
 
     connect(ui->changeCacheBtn, &QPushButton::clicked, this, &MainWindow::onSetCacheFolder);
 }
@@ -80,6 +103,8 @@ void MainWindow::saveSettings() {
     settings.setValue("scaleRaw", ui->scaleRawCheckBox->checkState() == Qt::CheckState::Checked);
     settings.setValue("cachePath", mCacheRootFolder);
     settings.setValue("draftQuality", mDraftQuality);
+    settings.setValue("calibrationFile", mCalibrationFile);
+    settings.setValue("selectedCalibration", mSelectedProfile);
 
     // Save mounted files
     settings.beginWriteArray("mountedFiles");
@@ -104,8 +129,25 @@ void MainWindow::restoreSettings() {
     ui->scaleRawCheckBox->setCheckState(
         settings.value("scaleRaw").toBool() ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);
 
-    mCacheRootFolder = settings.value("cachePath").toString();    
+    mCacheRootFolder = settings.value("cachePath").toString();
     mDraftQuality = std::max(1, settings.value("draftQuality").toInt());
+    mCalibrationFile = settings.value("calibrationFile").toString();
+    mSelectedProfile = settings.value("selectedCalibration").toString();
+
+    if(!mCalibrationFile.isEmpty() && QFile::exists(mCalibrationFile)) {
+        try {
+            mCalibrationProfiles = loadCalibrationProfiles(mCalibrationFile.toStdString());
+            ui->calibrationProfileCombo->clear();
+            for(const auto& kv : mCalibrationProfiles)
+                ui->calibrationProfileCombo->addItem(QString::fromStdString(kv.first));
+        } catch(std::exception& e) {
+            QMessageBox::warning(this, "Calibration", QString("Failed to load calibration file: %1").arg(e.what()));
+        }
+    }
+
+    int idx = ui->calibrationProfileCombo->findText(mSelectedProfile);
+    if(idx >= 0)
+        ui->calibrationProfileCombo->setCurrentIndex(idx);
 
     if(mDraftQuality == 2)
         ui->draftQuality->setCurrentIndex(0);
@@ -183,6 +225,9 @@ void MainWindow::mountFile(const QString& filePath) {
     try {
         mountId = mFuseFilesystem->mount(
             getRenderOptions(*ui), mDraftQuality, filePath.toStdString(), dstPath.toStdString());
+        auto profIt = mCalibrationProfiles.find(mSelectedProfile.toStdString());
+        const CalibrationProfile* profile = (profIt == mCalibrationProfiles.end()) ? nullptr : &profIt->second;
+        mFuseFilesystem->updateOptions(mountId, getRenderOptions(*ui), mDraftQuality, profile);
     }
     catch(std::runtime_error& e) {
         QMessageBox::critical(this, "Error", QString("There was an error mounting the file. (error: %1)").arg(e.what()));
@@ -314,7 +359,9 @@ void MainWindow::onRenderSettingsChanged(const Qt::CheckState &checkState) {
     updateUi();
 
     while(it != mMountedFiles.end()) {
-        mFuseFilesystem->updateOptions(it->mountId, renderOptions, mDraftQuality);
+        auto profIt = mCalibrationProfiles.find(mSelectedProfile.toStdString());
+        const CalibrationProfile* profile = (profIt == mCalibrationProfiles.end()) ? nullptr : &profIt->second;
+        mFuseFilesystem->updateOptions(it->mountId, renderOptions, mDraftQuality, profile);
         ++it;
     }
 }
@@ -342,4 +389,57 @@ void MainWindow::onSetCacheFolder(bool checked) {
 
     mCacheRootFolder = folderPath;
     ui->cacheFolderLabel->setText(mCacheRootFolder);
+}
+
+void MainWindow::onCalibrationProfileChanged(int index) {
+    if(index < 0)
+        return;
+    mSelectedProfile = ui->calibrationProfileCombo->currentText();
+    applyCalibration();
+}
+
+void MainWindow::applyCalibration() {
+    auto itProfile = mCalibrationProfiles.find(mSelectedProfile.toStdString());
+    const CalibrationProfile* profile = nullptr;
+    if(itProfile != mCalibrationProfiles.end())
+        profile = &itProfile->second;
+
+    auto renderOptions = getRenderOptions(*ui);
+    for(const auto& f : mMountedFiles)
+        mFuseFilesystem->updateOptions(f.mountId, renderOptions, mDraftQuality, profile);
+}
+
+void MainWindow::onUnmountAll() {
+    for(auto& f : mMountedFiles)
+        mFuseFilesystem->unmount(f.mountId);
+    mMountedFiles.clear();
+
+    auto* scrollContent = ui->dragAndDropScrollArea->widget();
+    auto* scrollLayout = qobject_cast<QVBoxLayout*>(scrollContent->layout());
+    while(auto item = scrollLayout->takeAt(0)) {
+        if(item->widget())
+            item->widget()->deleteLater();
+    }
+    ui->dragAndDropLabel->show();
+}
+
+void MainWindow::onAdvancedOptions() {
+    auto file = QFileDialog::getOpenFileName(this, tr("Load Calibration"), QString(), tr("JSON Files (*.json)"));
+    if(file.isEmpty())
+        return;
+
+    try {
+        mCalibrationProfiles = loadCalibrationProfiles(file.toStdString());
+        mCalibrationFile = file;
+        ui->calibrationProfileCombo->clear();
+        for(const auto& kv : mCalibrationProfiles)
+            ui->calibrationProfileCombo->addItem(QString::fromStdString(kv.first));
+        if(!mCalibrationProfiles.empty()) {
+            mSelectedProfile = QString::fromStdString(mCalibrationProfiles.begin()->first);
+            ui->calibrationProfileCombo->setCurrentIndex(0);
+            applyCalibration();
+        }
+    } catch(std::exception& e) {
+        QMessageBox::warning(this, tr("Error"), e.what());
+    }
 }

--- a/src/win/FuseFileSystemImpl_Win.cpp
+++ b/src/win/FuseFileSystemImpl_Win.cpp
@@ -81,7 +81,7 @@ public:
     ~Session();
 
 public:
-    void updateOptions(FileRenderOptions options, int draftScale);
+    void updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile);
 
 protected:
     HRESULT StartDirEnum(_In_ const PRJ_CALLBACK_DATA* CallbackData, _In_ const GUID* EnumerationId) override;
@@ -156,12 +156,12 @@ Session::~Session() {
     Stop();
 }
 
-void Session::updateOptions(FileRenderOptions options, int draftScale) {
+void Session::updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile) {
     mOptions = options;
     mDraftScale = draftScale;
 
     // Tell file system about new options
-    mFs->updateOptions(options, draftScale);
+    mFs->updateOptions(options, draftScale, profile);
 
     // We need to clear out the cache
     auto files = mFs->listFiles();
@@ -536,13 +536,13 @@ void FuseFileSystemImpl_Win::unmount(MountId mountId) {
     mMountedFiles.erase(mountId);
 }
 
-void FuseFileSystemImpl_Win::updateOptions(MountId mountId, FileRenderOptions options, int draftScale) {
+void FuseFileSystemImpl_Win::updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile) {
     auto it = mMountedFiles.find(mountId);
     if(it == mMountedFiles.end())
         return;
 
     dynamic_cast<Session*>(mMountedFiles[mountId].get())->updateOptions(
-        options, draftScale);
+        options, draftScale, profile);
 }
 
 } // namespace motioncam

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -143,8 +143,8 @@
           <string>Apply vignette correction</string>
          </property>
         </widget>
-       </item>
-       <item row="0" column="0">
+      </item>
+      <item row="0" column="0">
         <layout class="QHBoxLayout" name="draftLayout">
          <item>
           <widget class="QCheckBox" name="draftModeCheckBox">
@@ -185,10 +185,24 @@
           </widget>
          </item>
         </layout>
-       </item>
-      </layout>
-     </widget>
-    </item>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="calibrationLayout">
+        <item>
+         <widget class="QLabel" name="calibrationLabel">
+          <property name="text">
+           <string>Calibration</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="calibrationProfileCombo"/>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
    </layout>
   </widget>
  </widget>


### PR DESCRIPTION
## Summary
- add `CalibrationProfile` helper and loader
- add menu bar with File/Advanced/Help actions
- add calibration profile combo box and advanced options
- propagate calibration profile to file system implementations
- update virtual file system to use calibration overrides

## Testing
- `cmake -B build -S .` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_6862221ed39c83279b100e7d44f5e743