### PR TITLE
Add calibration options dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,12 +27,16 @@ set(PROJECT_SOURCES
         src/CameraFrameMetadata.cpp
         src/AudioWriter.cpp
         src/Utils.cpp
+        src/CalibrationProfile.cpp
+        src/AdvancedOptionsDialog.cpp
 
         include/mainwindow.h
+        include/AdvancedOptionsDialog.h
         include/Types.h
         include/IVirtualFileSystem.h
         include/IFuseFileSystem.h
         include/VirtualFileSystemImpl_MCRAW.h
+        include/CalibrationProfile.h
         include/LRUCache.h
         include/AudioWriter.h
         include/Measure.h
@@ -42,6 +46,7 @@ set(PROJECT_SOURCES
         include/Utils.h
 
         ui/mainwindow.ui
+        ui/advancedoptionsdialog.ui
 )
 
 qt_add_resources(PROJECT_SOURCES resources.qrc)

--- a/include/AdvancedOptionsDialog.h
+++ b/include/AdvancedOptionsDialog.h
@@ -1,0 +1,39 @@
+#pragma once
+#include <QDialog>
+#include "CalibrationProfile.h"
+#include <map>
+
+namespace Ui { class AdvancedOptionsDialog; }
+
+class AdvancedOptionsDialog : public QDialog {
+    Q_OBJECT
+public:
+    explicit AdvancedOptionsDialog(QWidget* parent = nullptr);
+    ~AdvancedOptionsDialog();
+
+    void setUniqueCameraModel(const QString& model);
+    QString uniqueCameraModel() const;
+
+    void setCalibrationFile(const QString& path);
+    QString calibrationFile() const;
+
+    void setCalibrationProfiles(const std::map<std::string, motioncam::CalibrationProfile>& profiles);
+    const std::map<std::string, motioncam::CalibrationProfile>& calibrationProfiles() const;
+
+    void setSelectedProfile(const QString& profile);
+    QString selectedProfile() const;
+
+private slots:
+    void onBrowseCalibration();
+    void onProfileChanged(int index);
+
+private:
+    void loadCalibrationFile(const QString& path);
+    void updateProfileDetails(const motioncam::CalibrationProfile& profile);
+
+private:
+    Ui::AdvancedOptionsDialog* ui;
+    std::map<std::string, motioncam::CalibrationProfile> mProfiles;
+    QString mCalibrationPath;
+};
+

--- a/include/CalibrationProfile.h
+++ b/include/CalibrationProfile.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <array>
+#include <string>
+#include <map>
+
+
+namespace motioncam {
+
+struct CalibrationProfile {
+    std::string uniqueCameraModel;
+    std::array<float, 9> colorMatrix1{};
+    std::array<float, 9> colorMatrix2{};
+    std::array<float, 9> forwardMatrix1{};
+    std::array<float, 9> forwardMatrix2{};
+    std::array<float, 9> calibrationMatrix1{};
+    std::array<float, 9> calibrationMatrix2{};
+    std::string colorIlluminant1;
+    std::string colorIlluminant2;
+    float baselineExposure{0.f};
+};
+
+std::map<std::string, CalibrationProfile> loadCalibrationProfiles(const std::string& path);
+
+} // namespace motioncam
+

--- a/include/IFuseFileSystem.h
+++ b/include/IFuseFileSystem.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "Types.h"
+#include "CalibrationProfile.h"
 
 namespace motioncam {
 
@@ -19,7 +20,7 @@ public:
 
     virtual MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) = 0;
     virtual void unmount(MountId mountId) = 0;
-    virtual void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) = 0;
+    virtual void updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile, const std::string* uniqueCameraModel) = 0;
 
 protected:
     IFuseFileSystem() = default;

--- a/include/IVirtualFileSystem.h
+++ b/include/IVirtualFileSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Types.h"
+#include "CalibrationProfile.h"
 
 #include <optional>
 #include <string>
@@ -26,7 +27,7 @@ public:
         std::function<void(size_t, int)> result,
         bool async) = 0;
 
-    virtual void updateOptions(FileRenderOptions options, int draftScale) = 0;
+    virtual void updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile, const std::string* uniqueCameraModel) = 0;
 
 protected:
     IVirtualFileSystem() = default;

--- a/include/VirtualFileSystemImpl_MCRAW.h
+++ b/include/VirtualFileSystemImpl_MCRAW.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <IVirtualFileSystem.h>
+#include "CalibrationProfile.h"
 
 namespace BS {
 class thread_pool;
@@ -35,7 +36,7 @@ public:
         std::function<void(size_t, int)> result,
         bool async=true) override;
 
-    void updateOptions(FileRenderOptions options, int draftScale) override;
+    void updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile, const std::string* uniqueCameraModel) override;
 
 private:
     void init(FileRenderOptions options);
@@ -69,6 +70,8 @@ private:
     FileRenderOptions mOptions;
     float mFps;
     std::mutex mMutex;
+    const CalibrationProfile* mCalibration;
+    std::string mUniqueCameraModel;
 };
 
 } // namespace motioncam

--- a/include/macos/FuseFileSystemImpl_MacOS.h
+++ b/include/macos/FuseFileSystemImpl_MacOS.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "IFuseFileSystem.h"
+#include "../CalibrationProfile.h"
 
 namespace BS {
     class thread_pool;
@@ -22,7 +23,7 @@ public:
 
     MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) override;
     void unmount(MountId mountId) override;
-    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) override;
+    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile, const std::string* uniqueCameraModel) override;
 
 private:
     MountId mNextMountId;

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -6,6 +6,8 @@
 #include <QMainWindow>
 #include <QList>
 #include <QString>
+#include <map>
+#include "CalibrationProfile.h"
 
 namespace motioncam {
     struct MountedFile {
@@ -66,6 +68,8 @@ private slots:
     void onRenderSettingsChanged(const Qt::CheckState &state);
     void onDraftModeQualityChanged(int index);
     void onSetCacheFolder(bool checked);
+    void onUnmountAll();
+    void onAdvancedOptions();
 
     void playFile(const QString& path);
     void removeFile(QWidget* fileWidget);
@@ -74,6 +78,7 @@ private:
     void saveSettings();
     void restoreSettings();
     void updateUi();
+    void applyCalibration();
 
 private:
     Ui::MainWindow *ui;
@@ -81,6 +86,10 @@ private:
     QList<motioncam::MountedFile> mMountedFiles;
     QString mCacheRootFolder;
     int mDraftQuality;
+    std::map<std::string, motioncam::CalibrationProfile> mCalibrationProfiles;
+    QString mCalibrationFile;
+    QString mSelectedProfile;
+    QString mUniqueCameraModel;
 };
 
 #endif // MAINWINDOW_H

--- a/include/win/FuseFileSystemImpl_Win.h
+++ b/include/win/FuseFileSystemImpl_Win.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "IFuseFileSystem.h"
+#include "../CalibrationProfile.h"
 
 namespace BS {
     class thread_pool;
@@ -21,7 +22,7 @@ public:
 
     MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) override;
     void unmount(MountId mountId) override;
-    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) override;
+    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile, const std::string* uniqueCameraModel) override;
 
 private:
     MountId mNextMountId;

--- a/src/AdvancedOptionsDialog.cpp
+++ b/src/AdvancedOptionsDialog.cpp
@@ -1,0 +1,108 @@
+#include "AdvancedOptionsDialog.h"
+#include "ui_advancedoptionsdialog.h"
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QStringList>
+
+AdvancedOptionsDialog::AdvancedOptionsDialog(QWidget* parent)
+    : QDialog(parent), ui(new Ui::AdvancedOptionsDialog)
+{
+    ui->setupUi(this);
+
+    connect(ui->browseCalibrationBtn, &QPushButton::clicked,
+            this, &AdvancedOptionsDialog::onBrowseCalibration);
+    connect(ui->profileCombo,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &AdvancedOptionsDialog::onProfileChanged);
+    connect(ui->buttonBox, &QDialogButtonBox::accepted,
+            this, &QDialog::accept);
+    connect(ui->buttonBox, &QDialogButtonBox::rejected,
+            this, &QDialog::reject);
+}
+
+AdvancedOptionsDialog::~AdvancedOptionsDialog() { delete ui; }
+
+void AdvancedOptionsDialog::setUniqueCameraModel(const QString& model) {
+    ui->uniqueCameraModelEdit->setText(model);
+}
+
+QString AdvancedOptionsDialog::uniqueCameraModel() const { return ui->uniqueCameraModelEdit->text(); }
+
+void AdvancedOptionsDialog::setCalibrationFile(const QString& path) {
+    mCalibrationPath = path;
+    ui->calibrationFileEdit->setText(path);
+}
+
+QString AdvancedOptionsDialog::calibrationFile() const { return mCalibrationPath; }
+
+void AdvancedOptionsDialog::setCalibrationProfiles(const std::map<std::string, motioncam::CalibrationProfile>& profiles) {
+    mProfiles = profiles;
+    ui->profileCombo->clear();
+    for(const auto& kv : mProfiles)
+        ui->profileCombo->addItem(QString::fromStdString(kv.first));
+}
+
+const std::map<std::string, motioncam::CalibrationProfile>& AdvancedOptionsDialog::calibrationProfiles() const {
+    return mProfiles;
+}
+
+void AdvancedOptionsDialog::setSelectedProfile(const QString& profile) {
+    int idx = ui->profileCombo->findText(profile);
+    if(idx >= 0)
+        ui->profileCombo->setCurrentIndex(idx);
+}
+
+QString AdvancedOptionsDialog::selectedProfile() const { return ui->profileCombo->currentText(); }
+
+void AdvancedOptionsDialog::onBrowseCalibration() {
+    auto file = QFileDialog::getOpenFileName(this, tr("Load Calibration"), QString(), tr("JSON Files (*.json)"));
+    if(file.isEmpty())
+        return;
+    loadCalibrationFile(file);
+}
+
+void AdvancedOptionsDialog::loadCalibrationFile(const QString& path) {
+    try {
+        mProfiles = motioncam::loadCalibrationProfiles(path.toStdString());
+        mCalibrationPath = path;
+        ui->calibrationFileEdit->setText(path);
+        ui->profileCombo->clear();
+        for(const auto& kv : mProfiles)
+            ui->profileCombo->addItem(QString::fromStdString(kv.first));
+        if(!mProfiles.empty())
+            ui->profileCombo->setCurrentIndex(0);
+    } catch(std::exception& e) {
+        QMessageBox::warning(this, tr("Error"), e.what());
+    }
+}
+
+void AdvancedOptionsDialog::onProfileChanged(int index) {
+    if(index < 0) return;
+    auto it = mProfiles.find(ui->profileCombo->currentText().toStdString());
+    if(it != mProfiles.end())
+        updateProfileDetails(it->second);
+}
+
+static QString arrayToString(const std::array<float,9>& arr) {
+    QStringList list;
+    for(float v : arr) list << QString::number(v);
+    return list.join(", ");
+}
+
+void AdvancedOptionsDialog::updateProfileDetails(const motioncam::CalibrationProfile& p) {
+    QString details;
+    if(!p.uniqueCameraModel.empty())
+        details += QStringLiteral("uniqueCameraModel: %1\n").arg(QString::fromStdString(p.uniqueCameraModel));
+    details += QStringLiteral("colorMatrix1: %1\n").arg(arrayToString(p.colorMatrix1));
+    details += QStringLiteral("colorMatrix2: %1\n").arg(arrayToString(p.colorMatrix2));
+    details += QStringLiteral("forwardMatrix1: %1\n").arg(arrayToString(p.forwardMatrix1));
+    details += QStringLiteral("forwardMatrix2: %1\n").arg(arrayToString(p.forwardMatrix2));
+    details += QStringLiteral("calibrationMatrix1: %1\n").arg(arrayToString(p.calibrationMatrix1));
+    details += QStringLiteral("calibrationMatrix2: %1\n").arg(arrayToString(p.calibrationMatrix2));
+    details += QStringLiteral("colorIlluminant1: %1\n").arg(QString::fromStdString(p.colorIlluminant1));
+    details += QStringLiteral("colorIlluminant2: %1\n").arg(QString::fromStdString(p.colorIlluminant2));
+    if(p.baselineExposure != 0.f)
+        details += QStringLiteral("baselineExposure: %1\n").arg(p.baselineExposure);
+    ui->profileDetails->setPlainText(details);
+}
+

--- a/src/CalibrationProfile.cpp
+++ b/src/CalibrationProfile.cpp
@@ -1,0 +1,45 @@
+#include "CalibrationProfile.h"
+
+#include <fstream>
+#include <stdexcept>
+#include <nlohmann/json.hpp>
+
+namespace motioncam {
+
+static std::array<float,9> toArray(const nlohmann::json& j) {
+    std::array<float,9> a{};
+    for(size_t i=0;i<9 && i<j.size();++i)
+        a[i] = j[i].get<float>();
+    return a;
+}
+
+std::map<std::string, CalibrationProfile> loadCalibrationProfiles(const std::string& path) {
+    std::ifstream f(path);
+    if(!f.is_open())
+        throw std::runtime_error("Failed to open calibration file");
+
+    nlohmann::json j;
+    f >> j;
+
+    std::map<std::string, CalibrationProfile> profiles;
+    for(auto it=j.begin(); it!=j.end(); ++it) {
+        CalibrationProfile p;
+        const auto& obj = it.value();
+        p.uniqueCameraModel = obj.value("uniqueCameraModel", "");
+        if(obj.contains("colorMatrix1")) p.colorMatrix1 = toArray(obj["colorMatrix1"]);
+        if(obj.contains("colorMatrix2")) p.colorMatrix2 = toArray(obj["colorMatrix2"]);
+        if(obj.contains("forwardMatrix1")) p.forwardMatrix1 = toArray(obj["forwardMatrix1"]);
+        if(obj.contains("forwardMatrix2")) p.forwardMatrix2 = toArray(obj["forwardMatrix2"]);
+        if(obj.contains("calibrationMatrix1")) p.calibrationMatrix1 = toArray(obj["calibrationMatrix1"]);
+        if(obj.contains("calibrationMatrix2")) p.calibrationMatrix2 = toArray(obj["calibrationMatrix2"]);
+        p.colorIlluminant1 = obj.value("colorIlluminant1", "");
+        p.colorIlluminant2 = obj.value("colorIlluminant2", "");
+        p.baselineExposure = obj.value("baselineExposure", 0.f);
+        profiles[it.key()] = p;
+    }
+
+    return profiles;
+}
+
+} // namespace motioncam
+

--- a/src/VirtualFileSystemImpl_MCRAW.cpp
+++ b/src/VirtualFileSystemImpl_MCRAW.cpp
@@ -194,7 +194,8 @@ VirtualFileSystemImpl_MCRAW::VirtualFileSystemImpl_MCRAW(
         mTypicalDngSize(0),
         mFps(0),
         mDraftScale(draftScale),
-        mOptions(options) {
+        mOptions(options),
+        mCalibration(nullptr) {
 
     init(options);
 }
@@ -383,7 +384,7 @@ size_t VirtualFileSystemImpl_MCRAW::generateFrame(
     const auto fps = mFps;
     const auto draftScale = mDraftScale;
 
-    auto generateTask = [&options = mOptions, &cache = mCache, entry, sharableFuture, fps, draftScale, pos, len, dst, result]() {
+    auto generateTask = [this, &options = mOptions, &cache = mCache, entry, sharableFuture, fps, draftScale, pos, len, dst, result]() {
         size_t readBytes = 0;
         int errorCode = -1;
 
@@ -392,6 +393,20 @@ size_t VirtualFileSystemImpl_MCRAW::generateFrame(
             auto [frameIndex, containerMetadata, frameMetadata, frameData] = std::move(decodedFrame);
 
             spdlog::debug("Generating {}", entry.name);
+
+            if(this->mCalibration) {
+                containerMetadata.colorMatrix1 = this->mCalibration->colorMatrix1;
+                containerMetadata.colorMatrix2 = this->mCalibration->colorMatrix2;
+                containerMetadata.forwardMatrix1 = this->mCalibration->forwardMatrix1;
+                containerMetadata.forwardMatrix2 = this->mCalibration->forwardMatrix2;
+                containerMetadata.calibrationMatrix1 = this->mCalibration->calibrationMatrix1;
+                containerMetadata.calibrationMatrix2 = this->mCalibration->calibrationMatrix2;
+                containerMetadata.colorIlluminant1 = this->mCalibration->colorIlluminant1;
+                containerMetadata.colorIlluminant2 = this->mCalibration->colorIlluminant2;
+            }
+            if(!this->mUniqueCameraModel.empty()) {
+                containerMetadata.extraData.postProcessSettings.metadata.buildModel = this->mUniqueCameraModel;
+            }
 
             auto dngData = utils::generateDng(
                 *frameData,
@@ -484,9 +499,11 @@ int VirtualFileSystemImpl_MCRAW::readFile(
     return -1;
 }
 
-void VirtualFileSystemImpl_MCRAW::updateOptions(FileRenderOptions options, int draftScale) {
+void VirtualFileSystemImpl_MCRAW::updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile, const std::string* uniqueCameraModel) {
     mDraftScale = draftScale;
     mOptions = options;
+    mCalibration = profile;
+    mUniqueCameraModel = uniqueCameraModel ? *uniqueCameraModel : std::string{};
 
     init(options);
 }

--- a/src/macos/FuseFileSystemImpl_MacOS.cpp
+++ b/src/macos/FuseFileSystemImpl_MacOS.cpp
@@ -73,7 +73,7 @@ public:
     Session(const std::string& srcFile, const std::string& dstPath, VirtualFileSystemImpl_MCRAW* fs);
     ~Session();
 
-    void updateOptions(FileRenderOptions options, int draftScale);
+    void updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile, const std::string* uniqueCameraModel);
 
 private:
     void init(VirtualFileSystemImpl_MCRAW* fs);
@@ -176,9 +176,9 @@ void Session::init(VirtualFileSystemImpl_MCRAW* fs) {
 
 }
 
-void Session::updateOptions(FileRenderOptions options, int draftScale) {
-    mFs->updateOptions(options, draftScale);
-
+void Session::updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile, const std::string* uniqueCameraModel) {
+    mFs->updateOptions(options, draftScale, profile, uniqueCameraModel);
+    
     fuse_invalidate_path(mFuse, mDstPath.c_str());
 
 }
@@ -415,10 +415,10 @@ void FuseFileSystemImpl_MacOs::unmount(MountId mountId) {
     }
 }
 
-void FuseFileSystemImpl_MacOs::updateOptions(MountId mountId, FileRenderOptions options, int draftScale) {
+void FuseFileSystemImpl_MacOs::updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile, const std::string* uniqueCameraModel) {
     auto it = mMountedFiles.find(mountId);
     if(it != mMountedFiles.end()) {
-        it->second->updateOptions(options, draftScale);
+        it->second->updateOptions(options, draftScale, profile, uniqueCameraModel);
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -10,6 +10,14 @@
 #include <QMessageBox>
 #include <QFileDialog>
 #include <QSettings>
+#include <QMenuBar>
+#include <QAction>
+#include "CalibrationProfile.h"
+#include "AdvancedOptionsDialog.h"
+#include <utility>
+
+using motioncam::CalibrationProfile;
+#include <QVBoxLayout>
 #include <algorithm>
 
 #ifdef _WIN32
@@ -44,6 +52,23 @@ MainWindow::MainWindow(QWidget *parent)
     , mDraftQuality(1)
 {
     ui->setupUi(this);
+
+    // Create menu bar
+    auto fileMenu = menuBar()->addMenu("&File");
+    auto unmountAction = fileMenu->addAction("Unmount All");
+    auto exitAction = fileMenu->addAction("Exit");
+    connect(unmountAction, &QAction::triggered, this, &MainWindow::onUnmountAll);
+    connect(exitAction, &QAction::triggered, this, &MainWindow::close);
+
+    auto advMenu = menuBar()->addMenu("&Advanced");
+    auto optionsAction = advMenu->addAction("Options...");
+    connect(optionsAction, &QAction::triggered, this, &MainWindow::onAdvancedOptions);
+
+    auto helpMenu = menuBar()->addMenu("&Help");
+    auto aboutAction = helpMenu->addAction("About");
+    connect(aboutAction, &QAction::triggered, [this]() {
+        QMessageBox::about(this, tr("About"), tr("MotionCam FS"));
+    });
 
 #ifdef _WIN32
     mFuseFilesystem = std::make_unique<motioncam::FuseFileSystemImpl_Win>();
@@ -80,6 +105,9 @@ void MainWindow::saveSettings() {
     settings.setValue("scaleRaw", ui->scaleRawCheckBox->checkState() == Qt::CheckState::Checked);
     settings.setValue("cachePath", mCacheRootFolder);
     settings.setValue("draftQuality", mDraftQuality);
+    settings.setValue("calibrationFile", mCalibrationFile);
+    settings.setValue("selectedCalibration", mSelectedProfile);
+    settings.setValue("uniqueCameraModel", mUniqueCameraModel);
 
     // Save mounted files
     settings.beginWriteArray("mountedFiles");
@@ -104,8 +132,19 @@ void MainWindow::restoreSettings() {
     ui->scaleRawCheckBox->setCheckState(
         settings.value("scaleRaw").toBool() ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);
 
-    mCacheRootFolder = settings.value("cachePath").toString();    
+    mCacheRootFolder = settings.value("cachePath").toString();
     mDraftQuality = std::max(1, settings.value("draftQuality").toInt());
+    mCalibrationFile = settings.value("calibrationFile").toString();
+    mSelectedProfile = settings.value("selectedCalibration").toString();
+    mUniqueCameraModel = settings.value("uniqueCameraModel").toString();
+
+    if(!mCalibrationFile.isEmpty() && QFile::exists(mCalibrationFile)) {
+        try {
+            mCalibrationProfiles = motioncam::loadCalibrationProfiles(mCalibrationFile.toStdString());
+        } catch(std::exception& e) {
+            QMessageBox::warning(this, "Calibration", QString("Failed to load calibration file: %1").arg(e.what()));
+        }
+    }
 
     if(mDraftQuality == 2)
         ui->draftQuality->setCurrentIndex(0);
@@ -183,6 +222,11 @@ void MainWindow::mountFile(const QString& filePath) {
     try {
         mountId = mFuseFilesystem->mount(
             getRenderOptions(*ui), mDraftQuality, filePath.toStdString(), dstPath.toStdString());
+        auto profIt = mCalibrationProfiles.find(mSelectedProfile.toStdString());
+        const motioncam::CalibrationProfile* profile = (profIt == mCalibrationProfiles.end()) ? nullptr : &profIt->second;
+        std::string modelStr = mUniqueCameraModel.toStdString();
+        const std::string* modelPtr = modelStr.empty() ? nullptr : &modelStr;
+        mFuseFilesystem->updateOptions(mountId, getRenderOptions(*ui), mDraftQuality, profile, modelPtr);
     }
     catch(std::runtime_error& e) {
         QMessageBox::critical(this, "Error", QString("There was an error mounting the file. (error: %1)").arg(e.what()));
@@ -313,8 +357,12 @@ void MainWindow::onRenderSettingsChanged(const Qt::CheckState &checkState) {
 
     updateUi();
 
+    std::string modelStr = mUniqueCameraModel.toStdString();
+    const std::string* modelPtr = modelStr.empty() ? nullptr : &modelStr;
     while(it != mMountedFiles.end()) {
-        mFuseFilesystem->updateOptions(it->mountId, renderOptions, mDraftQuality);
+        auto profIt = mCalibrationProfiles.find(mSelectedProfile.toStdString());
+        const motioncam::CalibrationProfile* profile = (profIt == mCalibrationProfiles.end()) ? nullptr : &profIt->second;
+        mFuseFilesystem->updateOptions(it->mountId, renderOptions, mDraftQuality, profile, modelPtr);
         ++it;
     }
 }
@@ -342,4 +390,48 @@ void MainWindow::onSetCacheFolder(bool checked) {
 
     mCacheRootFolder = folderPath;
     ui->cacheFolderLabel->setText(mCacheRootFolder);
+}
+
+void MainWindow::applyCalibration() {
+    auto itProfile = mCalibrationProfiles.find(mSelectedProfile.toStdString());
+    const motioncam::CalibrationProfile* profile = nullptr;
+    if(itProfile != mCalibrationProfiles.end())
+        profile = &itProfile->second;
+
+    std::string modelStr = mUniqueCameraModel.toStdString();
+    const std::string* modelPtr = modelStr.empty() ? nullptr : &modelStr;
+
+    auto renderOptions = getRenderOptions(*ui);
+    for(const auto& f : mMountedFiles)
+        mFuseFilesystem->updateOptions(f.mountId, renderOptions, mDraftQuality, profile, modelPtr);
+}
+
+void MainWindow::onUnmountAll() {
+    for(auto& f : mMountedFiles)
+        mFuseFilesystem->unmount(f.mountId);
+    mMountedFiles.clear();
+
+    auto* scrollContent = ui->dragAndDropScrollArea->widget();
+    auto* scrollLayout = qobject_cast<QVBoxLayout*>(scrollContent->layout());
+    while(auto item = scrollLayout->takeAt(0)) {
+        if(item->widget())
+            item->widget()->deleteLater();
+    }
+    ui->dragAndDropLabel->show();
+}
+
+void MainWindow::onAdvancedOptions() {
+    AdvancedOptionsDialog dlg(this);
+    dlg.setUniqueCameraModel(mUniqueCameraModel);
+    dlg.setCalibrationFile(mCalibrationFile);
+    dlg.setCalibrationProfiles(mCalibrationProfiles);
+    dlg.setSelectedProfile(mSelectedProfile);
+
+    if(dlg.exec() == QDialog::Accepted) {
+        mUniqueCameraModel = dlg.uniqueCameraModel();
+        mCalibrationFile = dlg.calibrationFile();
+        mCalibrationProfiles = dlg.calibrationProfiles();
+        mSelectedProfile = dlg.selectedProfile();
+        applyCalibration();
+    }
 }

--- a/src/win/FuseFileSystemImpl_Win.cpp
+++ b/src/win/FuseFileSystemImpl_Win.cpp
@@ -81,7 +81,7 @@ public:
     ~Session();
 
 public:
-    void updateOptions(FileRenderOptions options, int draftScale);
+    void updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile, const std::string* uniqueCameraModel);
 
 protected:
     HRESULT StartDirEnum(_In_ const PRJ_CALLBACK_DATA* CallbackData, _In_ const GUID* EnumerationId) override;
@@ -156,12 +156,12 @@ Session::~Session() {
     Stop();
 }
 
-void Session::updateOptions(FileRenderOptions options, int draftScale) {
+void Session::updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile, const std::string* uniqueCameraModel) {
     mOptions = options;
     mDraftScale = draftScale;
 
     // Tell file system about new options
-    mFs->updateOptions(options, draftScale);
+    mFs->updateOptions(options, draftScale, profile, uniqueCameraModel);
 
     // We need to clear out the cache
     auto files = mFs->listFiles();
@@ -536,13 +536,13 @@ void FuseFileSystemImpl_Win::unmount(MountId mountId) {
     mMountedFiles.erase(mountId);
 }
 
-void FuseFileSystemImpl_Win::updateOptions(MountId mountId, FileRenderOptions options, int draftScale) {
+void FuseFileSystemImpl_Win::updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile, const std::string* uniqueCameraModel) {
     auto it = mMountedFiles.find(mountId);
     if(it == mMountedFiles.end())
         return;
 
     dynamic_cast<Session*>(mMountedFiles[mountId].get())->updateOptions(
-        options, draftScale);
+        options, draftScale, profile, uniqueCameraModel);
 }
 
 } // namespace motioncam

--- a/ui/advancedoptionsdialog.ui
+++ b/ui/advancedoptionsdialog.ui
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AdvancedOptionsDialog</class>
+ <widget class="QDialog" name="AdvancedOptionsDialog">
+  <property name="windowTitle">
+   <string>Advanced Options</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="modelGroup">
+     <property name="title">
+      <string>uniqueCameraModel</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLineEdit" name="uniqueCameraModelEdit"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="calibrationGroup">
+     <property name="title">
+      <string>Matrix Calibration</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLineEdit" name="calibrationFileEdit">
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="browseCalibrationBtn">
+          <property name="text">
+           <string>Load...</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QComboBox" name="profileCombo"/>
+      </item>
+      <item>
+       <widget class="QPlainTextEdit" name="profileDetails">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -143,8 +143,8 @@
           <string>Apply vignette correction</string>
          </property>
         </widget>
-       </item>
-       <item row="0" column="0">
+      </item>
+      <item row="0" column="0">
         <layout class="QHBoxLayout" name="draftLayout">
          <item>
           <widget class="QCheckBox" name="draftModeCheckBox">
@@ -185,10 +185,10 @@
           </widget>
          </item>
         </layout>
-       </item>
-      </layout>
-     </widget>
-    </item>
+      </item>
+     </layout>
+    </widget>
+   </item>
    </layout>
   </widget>
  </widget>


### PR DESCRIPTION
## Summary
- introduce a menu bar with File/Advanced/Help entries
- implement an advanced options dialog to manage calibration profiles
- remove the file loader for uniqueCameraModel so it is entered manually
- fix missing include in CalibrationProfile loader
- connect OK and Cancel buttons in the advanced options dialog

## Testing
- `cmake -B build -S .` *(fails: Could NOT find Boost 1.86.0)*

------
https://chatgpt.com/codex/tasks/task_e_6862221ed39c83279b100e7d44f5e743