### PR TITLE
Remove calibration profiles UI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,10 @@ set(PROJECT_SOURCES
         src/CameraFrameMetadata.cpp
         src/AudioWriter.cpp
         src/Utils.cpp
+        src/AdvancedOptionsDialog.cpp
 
         include/mainwindow.h
+        include/AdvancedOptionsDialog.h
         include/Types.h
         include/IVirtualFileSystem.h
         include/IFuseFileSystem.h
@@ -42,6 +44,7 @@ set(PROJECT_SOURCES
         include/Utils.h
 
         ui/mainwindow.ui
+        ui/advancedoptionsdialog.ui
 )
 
 qt_add_resources(PROJECT_SOURCES resources.qrc)

--- a/include/AdvancedOptionsDialog.h
+++ b/include/AdvancedOptionsDialog.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <QDialog>
+namespace Ui { class AdvancedOptionsDialog; }
+
+class AdvancedOptionsDialog : public QDialog {
+    Q_OBJECT
+public:
+    explicit AdvancedOptionsDialog(QWidget* parent = nullptr);
+    ~AdvancedOptionsDialog();
+
+    void setUniqueCameraModel(const QString& model);
+    QString uniqueCameraModel() const;
+
+private slots:
+
+private:
+    Ui::AdvancedOptionsDialog* ui;
+};
+

--- a/include/IFuseFileSystem.h
+++ b/include/IFuseFileSystem.h
@@ -19,7 +19,7 @@ public:
 
     virtual MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) = 0;
     virtual void unmount(MountId mountId) = 0;
-    virtual void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) = 0;
+    virtual void updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const std::string* uniqueCameraModel) = 0;
 
 protected:
     IFuseFileSystem() = default;

--- a/include/IVirtualFileSystem.h
+++ b/include/IVirtualFileSystem.h
@@ -26,7 +26,7 @@ public:
         std::function<void(size_t, int)> result,
         bool async) = 0;
 
-    virtual void updateOptions(FileRenderOptions options, int draftScale) = 0;
+    virtual void updateOptions(FileRenderOptions options, int draftScale, const std::string* uniqueCameraModel) = 0;
 
 protected:
     IVirtualFileSystem() = default;

--- a/include/VirtualFileSystemImpl_MCRAW.h
+++ b/include/VirtualFileSystemImpl_MCRAW.h
@@ -35,7 +35,7 @@ public:
         std::function<void(size_t, int)> result,
         bool async=true) override;
 
-    void updateOptions(FileRenderOptions options, int draftScale) override;
+    void updateOptions(FileRenderOptions options, int draftScale, const std::string* uniqueCameraModel) override;
 
 private:
     void init(FileRenderOptions options);
@@ -69,6 +69,7 @@ private:
     FileRenderOptions mOptions;
     float mFps;
     std::mutex mMutex;
+    std::string mUniqueCameraModel;
 };
 
 } // namespace motioncam

--- a/include/macos/FuseFileSystemImpl_MacOS.h
+++ b/include/macos/FuseFileSystemImpl_MacOS.h
@@ -22,7 +22,7 @@ public:
 
     MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) override;
     void unmount(MountId mountId) override;
-    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) override;
+    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const std::string* uniqueCameraModel) override;
 
 private:
     MountId mNextMountId;

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -66,6 +66,8 @@ private slots:
     void onRenderSettingsChanged(const Qt::CheckState &state);
     void onDraftModeQualityChanged(int index);
     void onSetCacheFolder(bool checked);
+    void onUnmountAll();
+    void onAdvancedOptions();
 
     void playFile(const QString& path);
     void removeFile(QWidget* fileWidget);
@@ -81,6 +83,7 @@ private:
     QList<motioncam::MountedFile> mMountedFiles;
     QString mCacheRootFolder;
     int mDraftQuality;
+    QString mUniqueCameraModel;
 };
 
 #endif // MAINWINDOW_H

--- a/include/win/FuseFileSystemImpl_Win.h
+++ b/include/win/FuseFileSystemImpl_Win.h
@@ -21,7 +21,7 @@ public:
 
     MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) override;
     void unmount(MountId mountId) override;
-    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) override;
+    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const std::string* uniqueCameraModel) override;
 
 private:
     MountId mNextMountId;

--- a/src/AdvancedOptionsDialog.cpp
+++ b/src/AdvancedOptionsDialog.cpp
@@ -1,0 +1,29 @@
+#include "AdvancedOptionsDialog.h"
+#include "ui_advancedoptionsdialog.h"
+#include <QDialogButtonBox>
+
+AdvancedOptionsDialog::AdvancedOptionsDialog(QWidget* parent)
+    : QDialog(parent), ui(new Ui::AdvancedOptionsDialog)
+{
+    ui->setupUi(this);
+
+    connect(ui->buttonBox, &QDialogButtonBox::accepted,
+            this, &QDialog::accept);
+    connect(ui->buttonBox, &QDialogButtonBox::rejected,
+            this, &QDialog::reject);
+}
+
+AdvancedOptionsDialog::~AdvancedOptionsDialog()
+{
+    delete ui;
+}
+
+void AdvancedOptionsDialog::setUniqueCameraModel(const QString& model)
+{
+    ui->uniqueCameraModelEdit->setText(model);
+}
+
+QString AdvancedOptionsDialog::uniqueCameraModel() const
+{
+    return ui->uniqueCameraModelEdit->text();
+}

--- a/src/VirtualFileSystemImpl_MCRAW.cpp
+++ b/src/VirtualFileSystemImpl_MCRAW.cpp
@@ -383,7 +383,7 @@ size_t VirtualFileSystemImpl_MCRAW::generateFrame(
     const auto fps = mFps;
     const auto draftScale = mDraftScale;
 
-    auto generateTask = [&options = mOptions, &cache = mCache, entry, sharableFuture, fps, draftScale, pos, len, dst, result]() {
+    auto generateTask = [this, &options = mOptions, &cache = mCache, entry, sharableFuture, fps, draftScale, pos, len, dst, result]() {
         size_t readBytes = 0;
         int errorCode = -1;
 
@@ -392,6 +392,10 @@ size_t VirtualFileSystemImpl_MCRAW::generateFrame(
             auto [frameIndex, containerMetadata, frameMetadata, frameData] = std::move(decodedFrame);
 
             spdlog::debug("Generating {}", entry.name);
+
+            if(!this->mUniqueCameraModel.empty()) {
+                containerMetadata.extraData.postProcessSettings.metadata.buildModel = this->mUniqueCameraModel;
+            }
 
             auto dngData = utils::generateDng(
                 *frameData,
@@ -484,9 +488,10 @@ int VirtualFileSystemImpl_MCRAW::readFile(
     return -1;
 }
 
-void VirtualFileSystemImpl_MCRAW::updateOptions(FileRenderOptions options, int draftScale) {
+void VirtualFileSystemImpl_MCRAW::updateOptions(FileRenderOptions options, int draftScale, const std::string* uniqueCameraModel) {
     mDraftScale = draftScale;
     mOptions = options;
+    mUniqueCameraModel = uniqueCameraModel ? *uniqueCameraModel : std::string{};
 
     init(options);
 }

--- a/src/macos/FuseFileSystemImpl_MacOS.cpp
+++ b/src/macos/FuseFileSystemImpl_MacOS.cpp
@@ -73,7 +73,7 @@ public:
     Session(const std::string& srcFile, const std::string& dstPath, VirtualFileSystemImpl_MCRAW* fs);
     ~Session();
 
-    void updateOptions(FileRenderOptions options, int draftScale);
+    void updateOptions(FileRenderOptions options, int draftScale, const std::string* uniqueCameraModel);
 
 private:
     void init(VirtualFileSystemImpl_MCRAW* fs);
@@ -176,9 +176,9 @@ void Session::init(VirtualFileSystemImpl_MCRAW* fs) {
 
 }
 
-void Session::updateOptions(FileRenderOptions options, int draftScale) {
-    mFs->updateOptions(options, draftScale);
-
+void Session::updateOptions(FileRenderOptions options, int draftScale, const std::string* uniqueCameraModel) {
+    mFs->updateOptions(options, draftScale, uniqueCameraModel);
+    
     fuse_invalidate_path(mFuse, mDstPath.c_str());
 
 }
@@ -415,10 +415,10 @@ void FuseFileSystemImpl_MacOs::unmount(MountId mountId) {
     }
 }
 
-void FuseFileSystemImpl_MacOs::updateOptions(MountId mountId, FileRenderOptions options, int draftScale) {
+void FuseFileSystemImpl_MacOs::updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const std::string* uniqueCameraModel) {
     auto it = mMountedFiles.find(mountId);
     if(it != mMountedFiles.end()) {
-        it->second->updateOptions(options, draftScale);
+        it->second->updateOptions(options, draftScale, uniqueCameraModel);
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -10,6 +10,11 @@
 #include <QMessageBox>
 #include <QFileDialog>
 #include <QSettings>
+#include <QMenuBar>
+#include <QAction>
+#include "AdvancedOptionsDialog.h"
+#include <utility>
+#include <QVBoxLayout>
 #include <algorithm>
 
 #ifdef _WIN32
@@ -44,6 +49,23 @@ MainWindow::MainWindow(QWidget *parent)
     , mDraftQuality(1)
 {
     ui->setupUi(this);
+
+    // Create menu bar
+    auto fileMenu = menuBar()->addMenu("&File");
+    auto unmountAction = fileMenu->addAction("Unmount All");
+    auto exitAction = fileMenu->addAction("Exit");
+    connect(unmountAction, &QAction::triggered, this, &MainWindow::onUnmountAll);
+    connect(exitAction, &QAction::triggered, this, &MainWindow::close);
+
+    auto advMenu = menuBar()->addMenu("&Advanced");
+    auto optionsAction = advMenu->addAction("Options...");
+    connect(optionsAction, &QAction::triggered, this, &MainWindow::onAdvancedOptions);
+
+    auto helpMenu = menuBar()->addMenu("&Help");
+    auto aboutAction = helpMenu->addAction("About");
+    connect(aboutAction, &QAction::triggered, [this]() {
+        QMessageBox::about(this, tr("About"), tr("MotionCam FS"));
+    });
 
 #ifdef _WIN32
     mFuseFilesystem = std::make_unique<motioncam::FuseFileSystemImpl_Win>();
@@ -80,6 +102,7 @@ void MainWindow::saveSettings() {
     settings.setValue("scaleRaw", ui->scaleRawCheckBox->checkState() == Qt::CheckState::Checked);
     settings.setValue("cachePath", mCacheRootFolder);
     settings.setValue("draftQuality", mDraftQuality);
+    settings.setValue("uniqueCameraModel", mUniqueCameraModel);
 
     // Save mounted files
     settings.beginWriteArray("mountedFiles");
@@ -104,8 +127,9 @@ void MainWindow::restoreSettings() {
     ui->scaleRawCheckBox->setCheckState(
         settings.value("scaleRaw").toBool() ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);
 
-    mCacheRootFolder = settings.value("cachePath").toString();    
+    mCacheRootFolder = settings.value("cachePath").toString();
     mDraftQuality = std::max(1, settings.value("draftQuality").toInt());
+    mUniqueCameraModel = settings.value("uniqueCameraModel").toString();
 
     if(mDraftQuality == 2)
         ui->draftQuality->setCurrentIndex(0);
@@ -183,6 +207,9 @@ void MainWindow::mountFile(const QString& filePath) {
     try {
         mountId = mFuseFilesystem->mount(
             getRenderOptions(*ui), mDraftQuality, filePath.toStdString(), dstPath.toStdString());
+        std::string modelStr = mUniqueCameraModel.toStdString();
+        const std::string* modelPtr = modelStr.empty() ? nullptr : &modelStr;
+        mFuseFilesystem->updateOptions(mountId, getRenderOptions(*ui), mDraftQuality, modelPtr);
     }
     catch(std::runtime_error& e) {
         QMessageBox::critical(this, "Error", QString("There was an error mounting the file. (error: %1)").arg(e.what()));
@@ -313,8 +340,10 @@ void MainWindow::onRenderSettingsChanged(const Qt::CheckState &checkState) {
 
     updateUi();
 
+    std::string modelStr = mUniqueCameraModel.toStdString();
+    const std::string* modelPtr = modelStr.empty() ? nullptr : &modelStr;
     while(it != mMountedFiles.end()) {
-        mFuseFilesystem->updateOptions(it->mountId, renderOptions, mDraftQuality);
+        mFuseFilesystem->updateOptions(it->mountId, renderOptions, mDraftQuality, modelPtr);
         ++it;
     }
 }
@@ -342,4 +371,34 @@ void MainWindow::onSetCacheFolder(bool checked) {
 
     mCacheRootFolder = folderPath;
     ui->cacheFolderLabel->setText(mCacheRootFolder);
+}
+
+
+void MainWindow::onUnmountAll() {
+    for(auto& f : mMountedFiles)
+        mFuseFilesystem->unmount(f.mountId);
+    mMountedFiles.clear();
+
+    auto* scrollContent = ui->dragAndDropScrollArea->widget();
+    auto* scrollLayout = qobject_cast<QVBoxLayout*>(scrollContent->layout());
+    while(auto item = scrollLayout->takeAt(0)) {
+        if(item->widget())
+            item->widget()->deleteLater();
+    }
+    ui->dragAndDropLabel->show();
+}
+
+void MainWindow::onAdvancedOptions() {
+    AdvancedOptionsDialog dlg(this);
+    dlg.setUniqueCameraModel(mUniqueCameraModel);
+
+    if(dlg.exec() == QDialog::Accepted) {
+        mUniqueCameraModel = dlg.uniqueCameraModel();
+
+        std::string modelStr = mUniqueCameraModel.toStdString();
+        const std::string* modelPtr = modelStr.empty() ? nullptr : &modelStr;
+        auto renderOptions = getRenderOptions(*ui);
+        for(const auto& f : mMountedFiles)
+            mFuseFilesystem->updateOptions(f.mountId, renderOptions, mDraftQuality, modelPtr);
+    }
 }

--- a/src/win/FuseFileSystemImpl_Win.cpp
+++ b/src/win/FuseFileSystemImpl_Win.cpp
@@ -81,7 +81,7 @@ public:
     ~Session();
 
 public:
-    void updateOptions(FileRenderOptions options, int draftScale);
+    void updateOptions(FileRenderOptions options, int draftScale, const std::string* uniqueCameraModel);
 
 protected:
     HRESULT StartDirEnum(_In_ const PRJ_CALLBACK_DATA* CallbackData, _In_ const GUID* EnumerationId) override;
@@ -156,12 +156,12 @@ Session::~Session() {
     Stop();
 }
 
-void Session::updateOptions(FileRenderOptions options, int draftScale) {
+void Session::updateOptions(FileRenderOptions options, int draftScale, const std::string* uniqueCameraModel) {
     mOptions = options;
     mDraftScale = draftScale;
 
     // Tell file system about new options
-    mFs->updateOptions(options, draftScale);
+    mFs->updateOptions(options, draftScale, uniqueCameraModel);
 
     // We need to clear out the cache
     auto files = mFs->listFiles();
@@ -536,13 +536,13 @@ void FuseFileSystemImpl_Win::unmount(MountId mountId) {
     mMountedFiles.erase(mountId);
 }
 
-void FuseFileSystemImpl_Win::updateOptions(MountId mountId, FileRenderOptions options, int draftScale) {
+void FuseFileSystemImpl_Win::updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const std::string* uniqueCameraModel) {
     auto it = mMountedFiles.find(mountId);
     if(it == mMountedFiles.end())
         return;
 
     dynamic_cast<Session*>(mMountedFiles[mountId].get())->updateOptions(
-        options, draftScale);
+        options, draftScale, uniqueCameraModel);
 }
 
 } // namespace motioncam

--- a/ui/advancedoptionsdialog.ui
+++ b/ui/advancedoptionsdialog.ui
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AdvancedOptionsDialog</class>
+ <widget class="QDialog" name="AdvancedOptionsDialog">
+  <property name="windowTitle">
+   <string>Advanced Options</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="modelGroup">
+     <property name="title">
+      <string>uniqueCameraModel</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLineEdit" name="uniqueCameraModelEdit"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -143,8 +143,8 @@
           <string>Apply vignette correction</string>
          </property>
         </widget>
-       </item>
-       <item row="0" column="0">
+      </item>
+      <item row="0" column="0">
         <layout class="QHBoxLayout" name="draftLayout">
          <item>
           <widget class="QCheckBox" name="draftModeCheckBox">
@@ -185,10 +185,10 @@
           </widget>
          </item>
         </layout>
-       </item>
-      </layout>
-     </widget>
-    </item>
+      </item>
+     </layout>
+    </widget>
+   </item>
    </layout>
   </widget>
  </widget>


### PR DESCRIPTION
## Summary
- drop calibration profile support
- keep only uniqueCameraModel field in advanced options dialog
- update FUSE APIs to accept the unique name only
- apply the uniqueCameraModel when rendering frames

## Testing
- `cmake -B build -S .` *(fails: Could NOT find Boost 1.86.0)*

------
https://chatgpt.com/codex/tasks/task_e_6862221ed39c83279b100e7d44f5e743