### PR TITLE
Invalidate cached frames on option change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,14 +27,18 @@ set(PROJECT_SOURCES
         src/CameraFrameMetadata.cpp
         src/AudioWriter.cpp
         src/Utils.cpp
+        src/CalibrationProfile.cpp
+        src/AdvancedOptionsDialog.cpp
 
         include/mainwindow.h
+        include/AdvancedOptionsDialog.h
         include/Types.h
         include/IVirtualFileSystem.h
         include/IFuseFileSystem.h
         include/VirtualFileSystemImpl_MCRAW.h
         include/LRUCache.h
         include/AudioWriter.h
+        include/CalibrationProfile.h
         include/Measure.h
         include/SingleApplication.h
         include/CameraMetadata.h
@@ -42,6 +46,7 @@ set(PROJECT_SOURCES
         include/Utils.h
 
         ui/mainwindow.ui
+        ui/advancedoptionsdialog.ui
 )
 
 qt_add_resources(PROJECT_SOURCES resources.qrc)

--- a/include/AdvancedOptionsDialog.h
+++ b/include/AdvancedOptionsDialog.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <QDialog>
+#include <map>
+#include "CalibrationProfile.h"
+namespace Ui { class AdvancedOptionsDialog; }
+
+class AdvancedOptionsDialog : public QDialog {
+    Q_OBJECT
+public:
+    explicit AdvancedOptionsDialog(QWidget* parent = nullptr);
+    ~AdvancedOptionsDialog();
+
+    void setUniqueCameraModel(const QString& model);
+    QString uniqueCameraModel() const;
+    void setCalibrationFile(const QString& file);
+    QString calibrationFile() const;
+    QString selectedProfile() const;
+    void setProfiles(const std::map<std::string, motioncam::CalibrationProfile>& profiles);
+
+private slots:
+    void onBrowse();
+
+private:
+    Ui::AdvancedOptionsDialog* ui;
+    QString mCalibrationFile;
+    std::map<std::string, motioncam::CalibrationProfile> mProfiles;
+};
+

--- a/include/CalibrationProfile.h
+++ b/include/CalibrationProfile.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <array>
+#include <string>
+#include <map>
+
+namespace motioncam {
+
+struct CalibrationProfile {
+    std::string uniqueCameraModel;
+    std::array<float,9> colorMatrix1{1,0,0,0,1,0,0,0,1};
+    std::array<float,9> colorMatrix2{1,0,0,0,1,0,0,0,1};
+    std::array<float,9> forwardMatrix1{1,0,0,0,1,0,0,0,1};
+    std::array<float,9> forwardMatrix2{1,0,0,0,1,0,0,0,1};
+    std::array<float,9> calibrationMatrix1{1,0,0,0,1,0,0,0,1};
+    std::array<float,9> calibrationMatrix2{1,0,0,0,1,0,0,0,1};
+    std::string colorIlluminant1{"d65"};
+    std::string colorIlluminant2{"d65"};
+};
+
+std::map<std::string, CalibrationProfile> loadCalibrationProfiles(const std::string& path);
+
+} // namespace motioncam

--- a/include/IFuseFileSystem.h
+++ b/include/IFuseFileSystem.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "Types.h"
+#include "CalibrationProfile.h"
 
 namespace motioncam {
 
@@ -19,7 +20,7 @@ public:
 
     virtual MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) = 0;
     virtual void unmount(MountId mountId) = 0;
-    virtual void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) = 0;
+    virtual void updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile) = 0;
 
 protected:
     IFuseFileSystem() = default;

--- a/include/IVirtualFileSystem.h
+++ b/include/IVirtualFileSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Types.h"
+#include "CalibrationProfile.h"
 
 #include <optional>
 #include <string>
@@ -26,7 +27,7 @@ public:
         std::function<void(size_t, int)> result,
         bool async) = 0;
 
-    virtual void updateOptions(FileRenderOptions options, int draftScale) = 0;
+    virtual void updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile) = 0;
 
 protected:
     IVirtualFileSystem() = default;

--- a/include/VirtualFileSystemImpl_MCRAW.h
+++ b/include/VirtualFileSystemImpl_MCRAW.h
@@ -35,7 +35,7 @@ public:
         std::function<void(size_t, int)> result,
         bool async=true) override;
 
-    void updateOptions(FileRenderOptions options, int draftScale) override;
+    void updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile) override;
 
 private:
     void init(FileRenderOptions options);
@@ -69,6 +69,7 @@ private:
     FileRenderOptions mOptions;
     float mFps;
     std::mutex mMutex;
+    const CalibrationProfile* mCalibration{nullptr};
 };
 
 } // namespace motioncam

--- a/include/macos/FuseFileSystemImpl_MacOS.h
+++ b/include/macos/FuseFileSystemImpl_MacOS.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "IFuseFileSystem.h"
+#include "CalibrationProfile.h"
 
 namespace BS {
     class thread_pool;
@@ -22,7 +23,7 @@ public:
 
     MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) override;
     void unmount(MountId mountId) override;
-    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) override;
+    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile) override;
 
 private:
     MountId mNextMountId;

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -2,6 +2,7 @@
 #define MAINWINDOW_H
 
 #include "IFuseFileSystem.h"
+#include "CalibrationProfile.h"
 
 #include <QMainWindow>
 #include <QList>
@@ -66,6 +67,8 @@ private slots:
     void onRenderSettingsChanged(const Qt::CheckState &state);
     void onDraftModeQualityChanged(int index);
     void onSetCacheFolder(bool checked);
+    void onUnmountAll();
+    void onAdvancedOptions();
 
     void playFile(const QString& path);
     void removeFile(QWidget* fileWidget);
@@ -81,6 +84,10 @@ private:
     QList<motioncam::MountedFile> mMountedFiles;
     QString mCacheRootFolder;
     int mDraftQuality;
+    QString mUniqueCameraModel;
+    QString mCalibrationFile;
+    QString mSelectedProfile;
+    std::map<std::string, motioncam::CalibrationProfile> mCalibrationProfiles;
 };
 
 #endif // MAINWINDOW_H

--- a/include/win/FuseFileSystemImpl_Win.h
+++ b/include/win/FuseFileSystemImpl_Win.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "IFuseFileSystem.h"
+#include "CalibrationProfile.h"
 
 namespace BS {
     class thread_pool;
@@ -21,7 +22,7 @@ public:
 
     MountId mount(FileRenderOptions options, int draftScale, const std::string& srcFile, const std::string& dstPath) override;
     void unmount(MountId mountId) override;
-    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale) override;
+    void updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile) override;
 
 private:
     MountId mNextMountId;

--- a/src/AdvancedOptionsDialog.cpp
+++ b/src/AdvancedOptionsDialog.cpp
@@ -1,0 +1,67 @@
+#include "AdvancedOptionsDialog.h"
+#include "ui_advancedoptionsdialog.h"
+#include <QDialogButtonBox>
+#include <QFileDialog>
+#include "CalibrationProfile.h"
+
+AdvancedOptionsDialog::AdvancedOptionsDialog(QWidget* parent)
+    : QDialog(parent), ui(new Ui::AdvancedOptionsDialog)
+{
+    ui->setupUi(this);
+
+    connect(ui->buttonBox, &QDialogButtonBox::accepted,
+            this, &QDialog::accept);
+    connect(ui->buttonBox, &QDialogButtonBox::rejected,
+            this, &QDialog::reject);
+
+    connect(ui->browseButton, &QPushButton::clicked, this, &AdvancedOptionsDialog::onBrowse);
+}
+
+AdvancedOptionsDialog::~AdvancedOptionsDialog()
+{
+    delete ui;
+}
+
+void AdvancedOptionsDialog::setUniqueCameraModel(const QString& model)
+{
+    ui->uniqueCameraModelEdit->setText(model);
+}
+
+QString AdvancedOptionsDialog::uniqueCameraModel() const
+{
+    return ui->uniqueCameraModelEdit->text();
+}
+
+void AdvancedOptionsDialog::setCalibrationFile(const QString& file)
+{
+    mCalibrationFile = file;
+    ui->calibrationFileEdit->setText(file);
+}
+
+QString AdvancedOptionsDialog::calibrationFile() const
+{
+    return ui->calibrationFileEdit->text();
+}
+
+QString AdvancedOptionsDialog::selectedProfile() const
+{
+    return ui->profileCombo->currentText();
+}
+
+void AdvancedOptionsDialog::setProfiles(const std::map<std::string, motioncam::CalibrationProfile>& profiles)
+{
+    mProfiles = profiles;
+    ui->profileCombo->clear();
+    for(const auto& kv : profiles)
+        ui->profileCombo->addItem(QString::fromStdString(kv.first));
+}
+
+void AdvancedOptionsDialog::onBrowse()
+{
+    auto path = QFileDialog::getOpenFileName(this, tr("Open Calibration"), QString(), tr("JSON Files (*.json)"));
+    if(path.isEmpty())
+        return;
+    setCalibrationFile(path);
+    mProfiles = motioncam::loadCalibrationProfiles(path.toStdString());
+    setProfiles(mProfiles);
+}

--- a/src/CalibrationProfile.cpp
+++ b/src/CalibrationProfile.cpp
@@ -1,0 +1,47 @@
+#include "CalibrationProfile.h"
+#include <nlohmann/json.hpp>
+#include <fstream>
+
+namespace motioncam {
+
+using json = nlohmann::json;
+
+static std::array<float,9> getMatrix(const json& j, const char* key) {
+    std::array<float,9> out{1,0,0,0,1,0,0,0,1};
+    if(j.contains(key) && j[key].is_array()) {
+        for(size_t i=0;i<9 && i<j[key].size();++i)
+            out[i] = j[key][i].get<float>();
+    }
+    return out;
+}
+
+std::map<std::string, CalibrationProfile> loadCalibrationProfiles(const std::string& path) {
+    std::map<std::string, CalibrationProfile> profiles;
+    std::ifstream f(path);
+    if(!f.is_open())
+        return profiles;
+    json j = json::parse(f, nullptr, false);
+    if(j.is_discarded() || !j.is_object())
+        return profiles;
+
+    for(auto it = j.begin(); it != j.end(); ++it) {
+        if(!it.value().is_object())
+            continue;
+        CalibrationProfile p;
+        auto obj = it.value();
+        p.uniqueCameraModel = obj.value("uniqueCameraModel", "");
+        p.colorMatrix1 = getMatrix(obj, "colorMatrix1");
+        p.colorMatrix2 = getMatrix(obj, "colorMatrix2");
+        p.forwardMatrix1 = getMatrix(obj, "forwardMatrix1");
+        p.forwardMatrix2 = getMatrix(obj, "forwardMatrix2");
+        p.calibrationMatrix1 = getMatrix(obj, "calibrationMatrix1");
+        p.calibrationMatrix2 = getMatrix(obj, "calibrationMatrix2");
+        p.colorIlluminant1 = obj.value("colorIlluminant1", "d65");
+        p.colorIlluminant2 = obj.value("colorIlluminant2", "d65");
+        profiles[it.key()] = p;
+    }
+
+    return profiles;
+}
+
+} // namespace motioncam

--- a/src/VirtualFileSystemImpl_MCRAW.cpp
+++ b/src/VirtualFileSystemImpl_MCRAW.cpp
@@ -383,7 +383,7 @@ size_t VirtualFileSystemImpl_MCRAW::generateFrame(
     const auto fps = mFps;
     const auto draftScale = mDraftScale;
 
-    auto generateTask = [&options = mOptions, &cache = mCache, entry, sharableFuture, fps, draftScale, pos, len, dst, result]() {
+    auto generateTask = [this, &options = mOptions, &cache = mCache, entry, sharableFuture, fps, draftScale, pos, len, dst, result]() {
         size_t readBytes = 0;
         int errorCode = -1;
 
@@ -392,6 +392,19 @@ size_t VirtualFileSystemImpl_MCRAW::generateFrame(
             auto [frameIndex, containerMetadata, frameMetadata, frameData] = std::move(decodedFrame);
 
             spdlog::debug("Generating {}", entry.name);
+
+            if(this->mCalibration) {
+                if(!this->mCalibration->uniqueCameraModel.empty())
+                    containerMetadata.extraData.postProcessSettings.metadata.buildModel = this->mCalibration->uniqueCameraModel;
+                containerMetadata.colorMatrix1 = this->mCalibration->colorMatrix1;
+                containerMetadata.colorMatrix2 = this->mCalibration->colorMatrix2;
+                containerMetadata.forwardMatrix1 = this->mCalibration->forwardMatrix1;
+                containerMetadata.forwardMatrix2 = this->mCalibration->forwardMatrix2;
+                containerMetadata.calibrationMatrix1 = this->mCalibration->calibrationMatrix1;
+                containerMetadata.calibrationMatrix2 = this->mCalibration->calibrationMatrix2;
+                containerMetadata.colorIlluminant1 = this->mCalibration->colorIlluminant1;
+                containerMetadata.colorIlluminant2 = this->mCalibration->colorIlluminant2;
+            }
 
             auto dngData = utils::generateDng(
                 *frameData,
@@ -484,9 +497,13 @@ int VirtualFileSystemImpl_MCRAW::readFile(
     return -1;
 }
 
-void VirtualFileSystemImpl_MCRAW::updateOptions(FileRenderOptions options, int draftScale) {
+void VirtualFileSystemImpl_MCRAW::updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile) {
     mDraftScale = draftScale;
     mOptions = options;
+    mCalibration = profile;
+
+    // Clear the cached frames so new options apply immediately
+    mCache.clear();
 
     init(options);
 }

--- a/src/macos/FuseFileSystemImpl_MacOS.cpp
+++ b/src/macos/FuseFileSystemImpl_MacOS.cpp
@@ -73,7 +73,7 @@ public:
     Session(const std::string& srcFile, const std::string& dstPath, VirtualFileSystemImpl_MCRAW* fs);
     ~Session();
 
-    void updateOptions(FileRenderOptions options, int draftScale);
+    void updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile);
 
 private:
     void init(VirtualFileSystemImpl_MCRAW* fs);
@@ -176,9 +176,9 @@ void Session::init(VirtualFileSystemImpl_MCRAW* fs) {
 
 }
 
-void Session::updateOptions(FileRenderOptions options, int draftScale) {
-    mFs->updateOptions(options, draftScale);
-
+void Session::updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile) {
+    mFs->updateOptions(options, draftScale, profile);
+    
     fuse_invalidate_path(mFuse, mDstPath.c_str());
 
 }
@@ -415,10 +415,10 @@ void FuseFileSystemImpl_MacOs::unmount(MountId mountId) {
     }
 }
 
-void FuseFileSystemImpl_MacOs::updateOptions(MountId mountId, FileRenderOptions options, int draftScale) {
+void FuseFileSystemImpl_MacOs::updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile) {
     auto it = mMountedFiles.find(mountId);
     if(it != mMountedFiles.end()) {
-        it->second->updateOptions(options, draftScale);
+        it->second->updateOptions(options, draftScale, profile);
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -10,6 +10,12 @@
 #include <QMessageBox>
 #include <QFileDialog>
 #include <QSettings>
+#include <QMenuBar>
+#include <QAction>
+#include "AdvancedOptionsDialog.h"
+#include "CalibrationProfile.h"
+#include <utility>
+#include <QVBoxLayout>
 #include <algorithm>
 
 #ifdef _WIN32
@@ -45,6 +51,23 @@ MainWindow::MainWindow(QWidget *parent)
 {
     ui->setupUi(this);
 
+    // Create menu bar
+    auto fileMenu = menuBar()->addMenu("&File");
+    auto unmountAction = fileMenu->addAction("Unmount All");
+    auto exitAction = fileMenu->addAction("Exit");
+    connect(unmountAction, &QAction::triggered, this, &MainWindow::onUnmountAll);
+    connect(exitAction, &QAction::triggered, this, &MainWindow::close);
+
+    auto advMenu = menuBar()->addMenu("&Advanced");
+    auto optionsAction = advMenu->addAction("Options...");
+    connect(optionsAction, &QAction::triggered, this, &MainWindow::onAdvancedOptions);
+
+    auto helpMenu = menuBar()->addMenu("&Help");
+    auto aboutAction = helpMenu->addAction("About");
+    connect(aboutAction, &QAction::triggered, [this]() {
+        QMessageBox::about(this, tr("About"), tr("MotionCam FS"));
+    });
+
 #ifdef _WIN32
     mFuseFilesystem = std::make_unique<motioncam::FuseFileSystemImpl_Win>();
 #elif __APPLE__
@@ -64,6 +87,10 @@ MainWindow::MainWindow(QWidget *parent)
     connect(ui->draftQuality, &QComboBox::currentIndexChanged, this, &MainWindow::onDraftModeQualityChanged);
 
     connect(ui->changeCacheBtn, &QPushButton::clicked, this, &MainWindow::onSetCacheFolder);
+    connect(ui->calibrationProfileCombo, &QComboBox::currentTextChanged, [this](const QString& text){
+        mSelectedProfile = (text == "None") ? QString() : text;
+        onRenderSettingsChanged(Qt::CheckState::Checked);
+    });
 }
 
 MainWindow::~MainWindow() {
@@ -80,6 +107,9 @@ void MainWindow::saveSettings() {
     settings.setValue("scaleRaw", ui->scaleRawCheckBox->checkState() == Qt::CheckState::Checked);
     settings.setValue("cachePath", mCacheRootFolder);
     settings.setValue("draftQuality", mDraftQuality);
+    settings.setValue("calibrationFile", mCalibrationFile);
+    settings.setValue("calibrationProfile", mSelectedProfile);
+    settings.setValue("uniqueCameraModel", mUniqueCameraModel);
 
     // Save mounted files
     settings.beginWriteArray("mountedFiles");
@@ -104,8 +134,19 @@ void MainWindow::restoreSettings() {
     ui->scaleRawCheckBox->setCheckState(
         settings.value("scaleRaw").toBool() ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);
 
-    mCacheRootFolder = settings.value("cachePath").toString();    
+    mCacheRootFolder = settings.value("cachePath").toString();
     mDraftQuality = std::max(1, settings.value("draftQuality").toInt());
+    mCalibrationFile = settings.value("calibrationFile").toString();
+    mSelectedProfile = settings.value("calibrationProfile").toString();
+    if(!mCalibrationFile.isEmpty()) {
+        mCalibrationProfiles = motioncam::loadCalibrationProfiles(mCalibrationFile.toStdString());
+        ui->calibrationProfileCombo->addItem("None");
+        for(const auto& kv : mCalibrationProfiles)
+            ui->calibrationProfileCombo->addItem(QString::fromStdString(kv.first));
+        if(!mSelectedProfile.isEmpty())
+            ui->calibrationProfileCombo->setCurrentText(mSelectedProfile);
+    }
+    mUniqueCameraModel = settings.value("uniqueCameraModel").toString();
 
     if(mDraftQuality == 2)
         ui->draftQuality->setCurrentIndex(0);
@@ -183,6 +224,13 @@ void MainWindow::mountFile(const QString& filePath) {
     try {
         mountId = mFuseFilesystem->mount(
             getRenderOptions(*ui), mDraftQuality, filePath.toStdString(), dstPath.toStdString());
+        const CalibrationProfile* profilePtr = nullptr;
+        if(!mSelectedProfile.isEmpty()) {
+            auto it = mCalibrationProfiles.find(mSelectedProfile.toStdString());
+            if(it != mCalibrationProfiles.end())
+                profilePtr = &it->second;
+        }
+        mFuseFilesystem->updateOptions(mountId, getRenderOptions(*ui), mDraftQuality, profilePtr);
     }
     catch(std::runtime_error& e) {
         QMessageBox::critical(this, "Error", QString("There was an error mounting the file. (error: %1)").arg(e.what()));
@@ -313,8 +361,14 @@ void MainWindow::onRenderSettingsChanged(const Qt::CheckState &checkState) {
 
     updateUi();
 
+    const CalibrationProfile* profilePtr = nullptr;
+    if(!mSelectedProfile.isEmpty()) {
+        auto itProf = mCalibrationProfiles.find(mSelectedProfile.toStdString());
+        if(itProf != mCalibrationProfiles.end())
+            profilePtr = &itProf->second;
+    }
     while(it != mMountedFiles.end()) {
-        mFuseFilesystem->updateOptions(it->mountId, renderOptions, mDraftQuality);
+        mFuseFilesystem->updateOptions(it->mountId, renderOptions, mDraftQuality, profilePtr);
         ++it;
     }
 }
@@ -342,4 +396,51 @@ void MainWindow::onSetCacheFolder(bool checked) {
 
     mCacheRootFolder = folderPath;
     ui->cacheFolderLabel->setText(mCacheRootFolder);
+}
+
+
+void MainWindow::onUnmountAll() {
+    for(auto& f : mMountedFiles)
+        mFuseFilesystem->unmount(f.mountId);
+    mMountedFiles.clear();
+
+    auto* scrollContent = ui->dragAndDropScrollArea->widget();
+    auto* scrollLayout = qobject_cast<QVBoxLayout*>(scrollContent->layout());
+    while(auto item = scrollLayout->takeAt(0)) {
+        if(item->widget())
+            item->widget()->deleteLater();
+    }
+    ui->dragAndDropLabel->show();
+}
+
+void MainWindow::onAdvancedOptions() {
+    AdvancedOptionsDialog dlg(this);
+    dlg.setUniqueCameraModel(mUniqueCameraModel);
+    dlg.setCalibrationFile(mCalibrationFile);
+    dlg.setProfiles(mCalibrationProfiles);
+
+    if(dlg.exec() == QDialog::Accepted) {
+        mUniqueCameraModel = dlg.uniqueCameraModel();
+        mCalibrationFile = dlg.calibrationFile();
+        mSelectedProfile = dlg.selectedProfile();
+        if(!mCalibrationFile.isEmpty())
+            mCalibrationProfiles = motioncam::loadCalibrationProfiles(mCalibrationFile.toStdString());
+
+        const CalibrationProfile* profilePtr = nullptr;
+        if(!mSelectedProfile.isEmpty()) {
+            auto it = mCalibrationProfiles.find(mSelectedProfile.toStdString());
+            if(it != mCalibrationProfiles.end())
+                profilePtr = &it->second;
+        }
+        auto renderOptions = getRenderOptions(*ui);
+        for(const auto& f : mMountedFiles)
+            mFuseFilesystem->updateOptions(f.mountId, renderOptions, mDraftQuality, profilePtr);
+
+        ui->calibrationProfileCombo->clear();
+        ui->calibrationProfileCombo->addItem("None");
+        for(const auto& kv : mCalibrationProfiles)
+            ui->calibrationProfileCombo->addItem(QString::fromStdString(kv.first));
+        if(!mSelectedProfile.isEmpty())
+            ui->calibrationProfileCombo->setCurrentText(mSelectedProfile);
+    }
 }

--- a/src/win/FuseFileSystemImpl_Win.cpp
+++ b/src/win/FuseFileSystemImpl_Win.cpp
@@ -81,7 +81,7 @@ public:
     ~Session();
 
 public:
-    void updateOptions(FileRenderOptions options, int draftScale);
+    void updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile);
 
 protected:
     HRESULT StartDirEnum(_In_ const PRJ_CALLBACK_DATA* CallbackData, _In_ const GUID* EnumerationId) override;
@@ -156,12 +156,12 @@ Session::~Session() {
     Stop();
 }
 
-void Session::updateOptions(FileRenderOptions options, int draftScale) {
+void Session::updateOptions(FileRenderOptions options, int draftScale, const CalibrationProfile* profile) {
     mOptions = options;
     mDraftScale = draftScale;
 
     // Tell file system about new options
-    mFs->updateOptions(options, draftScale);
+    mFs->updateOptions(options, draftScale, profile);
 
     // We need to clear out the cache
     auto files = mFs->listFiles();
@@ -536,13 +536,13 @@ void FuseFileSystemImpl_Win::unmount(MountId mountId) {
     mMountedFiles.erase(mountId);
 }
 
-void FuseFileSystemImpl_Win::updateOptions(MountId mountId, FileRenderOptions options, int draftScale) {
+void FuseFileSystemImpl_Win::updateOptions(MountId mountId, FileRenderOptions options, int draftScale, const CalibrationProfile* profile) {
     auto it = mMountedFiles.find(mountId);
     if(it == mMountedFiles.end())
         return;
 
     dynamic_cast<Session*>(mMountedFiles[mountId].get())->updateOptions(
-        options, draftScale);
+        options, draftScale, profile);
 }
 
 } // namespace motioncam

--- a/ui/advancedoptionsdialog.ui
+++ b/ui/advancedoptionsdialog.ui
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AdvancedOptionsDialog</class>
+ <widget class="QDialog" name="AdvancedOptionsDialog">
+  <property name="windowTitle">
+   <string>Advanced Options</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+   <widget class="QGroupBox" name="modelGroup">
+     <property name="title">
+      <string>uniqueCameraModel</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLineEdit" name="uniqueCameraModelEdit"/>
+      </item>
+     </layout>
+   </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="calibrationGroup">
+     <property name="title">
+      <string>Calibration</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QHBoxLayout" name="fileLayout">
+        <item>
+         <widget class="QLineEdit" name="calibrationFileEdit"/>
+        </item>
+        <item>
+         <widget class="QPushButton" name="browseButton">
+          <property name="text">
+           <string>Browse...</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QComboBox" name="profileCombo"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -183,12 +183,26 @@
             </property>
            </item>
           </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <layout class="QHBoxLayout" name="calibrationLayout">
+         <item>
+          <widget class="QLabel" name="calibrationLabel">
+           <property name="text">
+            <string>Calibration:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="calibrationProfileCombo"/>
          </item>
         </layout>
        </item>
       </layout>
-     </widget>
-    </item>
+      </item>
+     </layout>
+    </widget>
+   </item>
    </layout>
   </widget>
  </widget>


### PR DESCRIPTION
## Summary
- clear cached DNG frames when updating render options so new Unique Camera Model values apply
- add calibration profile handling and new advanced options dialog

## Testing
- `cmake -B build -S .` *(fails: Could NOT find Boost 1.86.0)*

------
https://chatgpt.com/codex/tasks/task_e_6862221ed39c83279b100e7d44f5e743